### PR TITLE
Allow reading a file already open in Excel

### DIFF
--- a/ImportExcel.psm1
+++ b/ImportExcel.psm1
@@ -2,20 +2,20 @@ Add-Type -Path "$($PSScriptRoot)\EPPlus.dll"
 
 function Import-Excel {
     param(
-        [Parameter(ValueFromPipelineByPropertyName=$true)]
-        $FullName,
+		[Alias("FullName")]
+        [Parameter(ValueFromPipelineByPropertyName=$true, ValueFromPipeline=$true, Mandatory)]
+        $Path,
         $Sheet=1,
         [string[]]$Header
     )
 
     Process {
 
-        $FullName = (Resolve-Path $FullName).Path
-        write-debug "target excel file $FullName"
+        $Path = (Resolve-Path $Path).Path
+        write-debug "target excel file $Path"
 		
-		$stream = New-Object System.IO.FileStream $FullName,"Open","Read","ReadWrite"
-
-        $xl = New-Object OfficeOpenXml.ExcelPackage $stream
+		$stream = New-Object -TypeName System.IO.FileStream -ArgumentList $Path,"Open","Read","ReadWrite"
+        $xl = New-Object -TypeName OfficeOpenXml.ExcelPackage -ArgumentList $stream
 
         $workbook  = $xl.Workbook
 
@@ -344,7 +344,8 @@ function ConvertFrom-ExcelSheet {
     )
 
     $Path = (Resolve-Path $Path).Path
-    $xl = New-Object -TypeName OfficeOpenXml.ExcelPackage -ArgumentList $Path
+	$stream = New-Object -TypeName System.IO.FileStream -ArgumentList $Path,"Open","Read","ReadWrite"
+    $xl = New-Object -TypeName OfficeOpenXml.ExcelPackage -ArgumentList $stream
     $workbook = $xl.Workbook
 
     $targetSheets = $workbook.Worksheets | Where {$_.Name -like $SheetName}

--- a/ImportExcel.psm1
+++ b/ImportExcel.psm1
@@ -328,6 +328,7 @@ function ConvertFrom-ExcelSheet {
     [CmdletBinding()]
     param
     (
+		[Alias("FullName")]
         [Parameter(Mandatory = $true)]
         [String]
         $Path,
@@ -363,7 +364,9 @@ function ConvertFrom-ExcelSheet {
 
         Import-Excel $Path -Sheet $($sheet.Name) | Export-Csv @params -Encoding $Encoding
     }
-
+	
+	$stream.Close()
+	$stream.Dispose()
     $xl.Dispose()
 }
 

--- a/ImportExcel.psm1
+++ b/ImportExcel.psm1
@@ -12,8 +12,10 @@ function Import-Excel {
 
         $FullName = (Resolve-Path $FullName).Path
         write-debug "target excel file $FullName"
+		
+		$stream = New-Object System.IO.FileStream $FullName,"Open","Read","ReadWrite"
 
-        $xl = New-Object OfficeOpenXml.ExcelPackage $FullName
+        $xl = New-Object OfficeOpenXml.ExcelPackage $stream
 
         $workbook  = $xl.Workbook
 
@@ -39,7 +41,9 @@ function Import-Excel {
             }
             [PSCustomObject]$h
         }
-
+		
+		$stream.Close()
+		$stream.Dispose()
         $xl.Dispose()
         $xl = $null
     }

--- a/TestImportExcel.ps1
+++ b/TestImportExcel.ps1
@@ -1,0 +1,3 @@
+Import-Module "$PSScriptRoot/ImportExcel" -Force
+
+Import-Excel "$PSScriptRoot/test.xlsx" -ErrorAction Stop


### PR DESCRIPTION
I've had a use case where I needed a file to be read while opened in Excel. 

It's a simple change, I doubt it will break anything.

The only thing this does is open the file handle with FileShare flag set to ReadWrite instead of Read, so it doesn't throw "The process cannot access the file 'X' because it is being used by another process" when trying to Import-Excel it.