### PR TITLE
ColumnSortOrder

### DIFF
--- a/Export-Excel.ps1
+++ b/Export-Excel.ps1
@@ -24,6 +24,8 @@ function Export-Excel {
         [bool]$TitleBold,
         [int]$TitleSize=22,
         [System.Drawing.Color]$TitleBackgroundColor,
+        [string[]]$ColumnSortOrder,
+        [switch]$OnlyExplicitColumns,
         [string[]]$PivotRows,
         [string[]]$PivotColumns,
         $PivotData,
@@ -135,9 +137,24 @@ function Export-Excel {
             if(!$Header) {
 
                 $ColumnIndex = $StartColumn
-
-                $Header = $TargetData.psobject.properties.name
-
+				
+				#Sort columns 
+				If ($ColumnSortOrder) {
+				
+					$Header = $ColumnSortOrder
+					
+					#Remove any invalid (as in "not a property of the object") columns 
+                    $Header = Compare-Object $ColumnSortOrder $TargetData.psobject.properties.name -IncludeEqual -ExcludeDifferent -Passthru
+					
+					If (-Not $OnlyExplicitColumns) {	
+						#Add additional properties that weren't part of the ColumnSortOrder list to the end of the table
+                        $Header = Compare-Object $Header $TargetData.psobject.properties.name -IncludeEqual -Passthru
+					}
+					
+				} Else {
+					$Header = $TargetData.psobject.properties.name
+				}
+	
                 if($NoHeader) {
                     # Don't push the headers to the spread sheet
                     $Row -= 1

--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ Known Issues
 What's new
 -
 
+#### 12/31/2015
+
+*Added parameters `PropertyNames`,`OnlyExplicitProperties` to allow ordering and filtering of columns
+
+Example
+
+	#write only process name, PID and CPU load in that order to the output
+	Get-Process | Export-Excel .\processes_sorted_filtered.xlsx -PropertyNames ProcessName,Id,'CPU(s)' -OnlyExplicitProperties
+
 #### 12/26/2015
 
 * Added `NoLegend`, `Show-Category`, `ShowPercent` for all charts including Pivot Charts


### PR DESCRIPTION
Added two parameters:
-ColumnSortOrder [string[]] Allows to have the
columns appear in a
specified order in the Excel sheet by passing the
object property names
as a list. Not specified properties will be added
to the end of the
table in unspecified order, unless
-OnlyExplicitColumns is specified
-OnlyExplicitColumns [switch] excludes
any columns from the output that
aren't specified in -ColumnSortOrder