### PR TITLE
Adding AllWorkSheets option to Import-Excel to return the complete document in one PSObject

### DIFF
--- a/ImportExcel.psm1
+++ b/ImportExcel.psm1
@@ -13,207 +13,207 @@ Add-Type -Path "$($PSScriptRoot)\EPPlus.dll"
 . $PSScriptRoot\Pivot.ps1
 
 function Import-Excel {
-            [cmdletBinding(DefaultParameterSetName='SingleSheet')]
-                param(
-                                [Alias('FullName')]
-                                [Parameter(ValueFromPipelineByPropertyName=$true, ValueFromPipeline=$true, Mandatory=$true,position=0)]
-                                $Path,
-                                [Parameter(ParameterSetName='SingleSheet')]
-                                [Alias('Sheet')]
-                                $WorkSheetname=1,
-                                [int]$HeaderRow=1,
-                                [string[]]$Header,
-                                [switch]$NoHeader,
-                                [parameter(ParameterSetName='AllSheets')]
-                                [Alias('AllSheets')]
-                                [switch]$AllWorkSheets
-                )
+   [cmdletBinding(DefaultParameterSetName='SingleSheet')]
+    param(
+        [Alias('FullName')]
+        [Parameter(ValueFromPipelineByPropertyName=$true, ValueFromPipeline=$true, Mandatory=$true,position=0)]
+        $Path,
+        [Parameter(ParameterSetName='SingleSheet')]
+        [Alias('Sheet')]
+        $WorkSheetname=1,
+        [int]$HeaderRow=1,
+        [string[]]$Header,
+        [switch]$NoHeader,
+        [parameter(ParameterSetName='AllSheets')]
+        [Alias('AllSheets')]
+        [switch]$AllWorkSheets
+    )
 
-                Process {
+    Process {
 
-                                $Path = (Resolve-Path $Path).Path
-                                write-debug "target excel file $Path"
+        $Path = (Resolve-Path $Path).Path
+        write-debug "target excel file $Path"
 
-                                $stream = New-Object -TypeName System.IO.FileStream -ArgumentList $Path,'Open','Read','ReadWrite'
-                                $xl = New-Object -TypeName OfficeOpenXml.ExcelPackage -ArgumentList $stream
+        $stream = New-Object -TypeName System.IO.FileStream -ArgumentList $Path,'Open','Read','ReadWrite'
+        $xl = New-Object -TypeName OfficeOpenXml.ExcelPackage -ArgumentList $stream
 
-                                $workbook  = $xl.Workbook
-                                if($AllWorkSheets) {
-                                    Write-Debug "Processing All $($xl.Workbook.Worksheets.Count) WorkSheets of the Workbook"
-                                    $worksheetsName = $xl.Workbook.worksheets.name
-                                    $WorkBookObject = [ordered]@{}
-                                }
-                                else {
-                                    $worksheetsName = $WorkSheetname
-                                }
+        $workbook  = $xl.Workbook
+        if($AllWorkSheets) {
+         Write-Debug "Processing All $($xl.Workbook.Worksheets.Count) WorkSheets of the Workbook"
+         $worksheetsName = $xl.Workbook.worksheets.name
+         $WorkBookObject = [ordered]@{}
+        }
+        else {
+         $worksheetsName = $WorkSheetname
+        }
 
+								
+        foreach ($WorkSheetname in $worksheetsName)
+        {
+         Write-Debug "Processing Worksheet $WorkSheetName"
+         $worksheet=$workbook.Worksheets[$WorkSheetname]
+         $dimension=$worksheet.Dimension
 
-                                foreach ($WorkSheetname in $worksheetsName)
-                                {
-                                    Write-Debug "Processing Worksheet $WorkSheetName"
-                                    $worksheet=$workbook.Worksheets[$WorkSheetname]
-                                    $dimension=$worksheet.Dimension
+         $Rows=$dimension.Rows
+         $Columns=$dimension.Columns
+         $SheetRows = @()
 
-                                    $Rows=$dimension.Rows
-                                    $Columns=$dimension.Columns
-                                    $SheetRows = @()
-
-                                    if($NoHeader) {
-                                                foreach ($Row in 0..($Rows-1)) {
-                                                                $newRow = [Ordered]@{}
-                                                                foreach ($Column in 0..($Columns-1)) {
-                                                                                $propertyName = "P$($Column+1)"
-                                                                                $newRow.$propertyName = $worksheet.Cells[($Row+1),($Column+1)].Value
-                                                                }
-
-                                                    if($AllWorkSheets) { $SheetRows += [PSCustomObject]$newRow }
-                                                    else {
-                                                        [PSCustomObject]$newRow
-                                                    }
-                                                }
-                                    } else {
-                                                if(!$Header) {
-                                                                $Header = foreach ($Column in 1..$Columns) {
-                                                                                $worksheet.Cells[$HeaderRow,$Column].Text
-                                                                }
-                                                }
-
-                                                foreach ($Row in ($HeaderRow+1)..$Rows) {
-                                                                $h=[Ordered]@{}
-                                                                foreach ($Column in 0..($Columns-1)) {
-                                                                                if($Header[$Column].Length -gt 0) {
-                                                                                                $Name    = $Header[$Column]
-                                                                                                $h.$Name = $worksheet.Cells[$Row,($Column+1)].Value
-                                                                                }
-                                                                }
-                                                    if($AllWorkSheets) { $SheetRows += [PSCustomObject]$h }
-                                                    else {
-                                                        [PSCustomObject]$h
-                                                    }
-																
-                                                }
-                                    }
-                                    if($AllWorkSheets) {
-                                        Write-Debug "Adding worksheet object $WorkSheetName to Workbook PSobject"
-                                        $WorkBookObject.add($WorkSheetname,$SheetRows);
-                                    }
-                                }
-                                if($AllWorkSheets) {
-                                    Write-Debug 'Writing the WorkbookObject to the Pipeline'
-                                    [PSCustomObject]$WorkBookObject
-                                }
-                                $stream.Close()
-                                $stream.Dispose()
-                                $xl.Dispose()
-                                $xl = $null
+         if($NoHeader) {
+            foreach ($Row in 0..($Rows-1)) {
+                $newRow = [Ordered]@{}
+                foreach ($Column in 0..($Columns-1)) {
+                    $propertyName = "P$($Column+1)"
+                    $newRow.$propertyName = $worksheet.Cells[($Row+1),($Column+1)].Value
                 }
+
+             if($AllWorkSheets) { $SheetRows += [PSCustomObject]$newRow }
+             else {
+              [PSCustomObject]$newRow
+             }
+            }
+         } else {
+            if(!$Header) {
+                $Header = foreach ($Column in 1..$Columns) {
+                    $worksheet.Cells[$HeaderRow,$Column].Text
+                }
+            }
+
+            foreach ($Row in ($HeaderRow+1)..$Rows) {
+                $h=[Ordered]@{}
+                foreach ($Column in 0..($Columns-1)) {
+                    if($Header[$Column].Length -gt 0) {
+                        $Name    = $Header[$Column]
+                        $h.$Name = $worksheet.Cells[$Row,($Column+1)].Value
+                    }
+                }
+             if($AllWorkSheets) { $SheetRows += [PSCustomObject]$h }
+             else {
+              [PSCustomObject]$h
+             }
+																
+            }
+         }
+         if($AllWorkSheets) {
+          Write-Debug "Adding worksheet object $WorkSheetName to Workbook PSobject"
+          $WorkBookObject.add($WorkSheetname,$SheetRows);
+         }
+        }
+        if($AllWorkSheets) {
+         Write-Debug 'Writing the WorkbookObject to the Pipeline'
+         [PSCustomObject]$WorkBookObject
+        }
+        $stream.Close()
+        $stream.Dispose()
+        $xl.Dispose()
+        $xl = $null
+    }
 }
 
 function Add-WorkSheet {
-                param(
-                                #TODO Use parametersets to allow a workbook to be passed instead of a package
-                                [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
-                                [OfficeOpenXml.ExcelPackage] $ExcelPackage,
-                                [Parameter(Mandatory=$true)]
-                                [string] $WorkSheetname,
-                                [Switch] $NoClobber
-                )
+    param(
+        #TODO Use parametersets to allow a workbook to be passed instead of a package
+        [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
+        [OfficeOpenXml.ExcelPackage] $ExcelPackage,
+        [Parameter(Mandatory=$true)]
+        [string] $WorkSheetname,
+        [Switch] $NoClobber
+    )
 
-                $ws = $ExcelPackage.Workbook.Worksheets[$WorkSheetname]
+    $ws = $ExcelPackage.Workbook.Worksheets[$WorkSheetname]
 
-                if(!$ws) {
-                                $ws=$ExcelPackage.Workbook.Worksheets.Add($WorkSheetname)
-                }
+    if(!$ws) {
+        $ws=$ExcelPackage.Workbook.Worksheets.Add($WorkSheetname)
+    }
 
-                return $ws
+    return $ws
 }
 
 function ConvertFrom-ExcelSheet {
-                <#
-                                .Synopsis
-                                Reads an Excel file an converts the data to a delimited text file
+    <#
+        .Synopsis
+        Reads an Excel file an converts the data to a delimited text file
 
-                                .Example
-                                ConvertFrom-ExcelSheet .\TestSheets.xlsx .\data
-                                Reads each sheet in TestSheets.xlsx and outputs it to the data directory as the sheet name with the extension .txt
+        .Example
+        ConvertFrom-ExcelSheet .\TestSheets.xlsx .\data
+        Reads each sheet in TestSheets.xlsx and outputs it to the data directory as the sheet name with the extension .txt
 
-                                .Example
-                                ConvertFrom-ExcelSheet .\TestSheets.xlsx .\data sheet?0
-                                Reads and outputs sheets like Sheet10 and Sheet20 form TestSheets.xlsx and outputs it to the data directory as the sheet name with the extension .txt
-                #>
+        .Example
+        ConvertFrom-ExcelSheet .\TestSheets.xlsx .\data sheet?0
+        Reads and outputs sheets like Sheet10 and Sheet20 form TestSheets.xlsx and outputs it to the data directory as the sheet name with the extension .txt
+    #>
 
-                [CmdletBinding()]
-                param
-                (
-                                [Alias('FullName')]
-                                [Parameter(Mandatory = $true)]
-                                [String]
-                                $Path,
-                                [String]
-                                $OutputPath = '.\',
-                                [String]
-                                $SheetName='*',
-                                [ValidateSet('ASCII', 'BigEndianUniCode','Default','OEM','UniCode','UTF32','UTF7','UTF8')]
-                                [string]
-                                $Encoding = 'UTF8',
-                                [ValidateSet('.txt', '.log','.csv')]
-                                [string]
-                                $Extension = '.csv',
-                                [ValidateSet(';', ',')]
-                                [string]
-                                $Delimiter = ';'
-                )
+    [CmdletBinding()]
+    param
+    (
+        [Alias('FullName')]
+        [Parameter(Mandatory = $true)]
+        [String]
+        $Path,
+        [String]
+        $OutputPath = '.\',
+        [String]
+        $SheetName='*',
+        [ValidateSet('ASCII', 'BigEndianUniCode','Default','OEM','UniCode','UTF32','UTF7','UTF8')]
+        [string]
+        $Encoding = 'UTF8',
+        [ValidateSet('.txt', '.log','.csv')]
+        [string]
+        $Extension = '.csv',
+        [ValidateSet(';', ',')]
+        [string]
+        $Delimiter = ';'
+    )
 
-                $Path = (Resolve-Path $Path).Path
-                $stream = New-Object -TypeName System.IO.FileStream -ArgumentList $Path,'Open','Read','ReadWrite'
-                $xl = New-Object -TypeName OfficeOpenXml.ExcelPackage -ArgumentList $stream
-                $workbook = $xl.Workbook
+    $Path = (Resolve-Path $Path).Path
+    $stream = New-Object -TypeName System.IO.FileStream -ArgumentList $Path,'Open','Read','ReadWrite'
+    $xl = New-Object -TypeName OfficeOpenXml.ExcelPackage -ArgumentList $stream
+    $workbook = $xl.Workbook
 
-                $targetSheets = $workbook.Worksheets | Where {$_.Name -like $SheetName}
+    $targetSheets = $workbook.Worksheets | Where {$_.Name -like $SheetName}
 
-                $params = @{} + $PSBoundParameters
-                $params.Remove('OutputPath')
-                $params.Remove('SheetName')
-                $params.Remove('Extension')
-                $params.NoTypeInformation = $true
+    $params = @{} + $PSBoundParameters
+    $params.Remove('OutputPath')
+    $params.Remove('SheetName')
+    $params.Remove('Extension')
+    $params.NoTypeInformation = $true
 
-                Foreach ($sheet in $targetSheets)
-                {
-                                Write-Verbose "Exporting sheet: $($sheet.Name)"
+    Foreach ($sheet in $targetSheets)
+    {
+        Write-Verbose "Exporting sheet: $($sheet.Name)"
 
-                                $params.Path = "$OutputPath\$($Sheet.Name)$Extension"
+        $params.Path = "$OutputPath\$($Sheet.Name)$Extension"
 
-                                Import-Excel $Path -Sheet $($sheet.Name) | Export-Csv @params
-                }
+        Import-Excel $Path -Sheet $($sheet.Name) | Export-Csv @params
+    }
 
-                $stream.Close()
-                $stream.Dispose()
-                $xl.Dispose()
+    $stream.Close()
+    $stream.Dispose()
+    $xl.Dispose()
 }
 
 function Export-MultipleExcelSheets {
-                param(
-                                [Parameter(Mandatory=$true)]
-                                $Path,
-                                [Parameter(Mandatory=$true)]
-                                [hashtable]$InfoMap,
-                                [string]$Password,
-                                [Switch]$Show,
-                                [Switch]$AutoSize
-                )
+    param(
+        [Parameter(Mandatory=$true)]
+        $Path,
+        [Parameter(Mandatory=$true)]
+        [hashtable]$InfoMap,
+        [string]$Password,
+        [Switch]$Show,
+        [Switch]$AutoSize
+    )
 
-                $parameters = @{}+$PSBoundParameters
-                $parameters.Remove('InfoMap')
-                $parameters.Remove('Show')
+    $parameters = @{}+$PSBoundParameters
+    $parameters.Remove('InfoMap')
+    $parameters.Remove('Show')
 
-                $parameters.Path = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Path)
+    $parameters.Path = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Path)
 
-                foreach ($entry in $InfoMap.GetEnumerator()) {
-                                Write-Progress -Activity 'Exporting' -Status "$($entry.Key)"
-                                $parameters.WorkSheetname=$entry.Key
+    foreach ($entry in $InfoMap.GetEnumerator()) {
+        Write-Progress -Activity 'Exporting' -Status "$($entry.Key)"
+        $parameters.WorkSheetname=$entry.Key
 
-                                & $entry.Value | Export-Excel @parameters
-                }
+        & $entry.Value | Export-Excel @parameters
+    }
 
-                if($Show) {Invoke-Item $Path}
+    if($Show) {Invoke-Item $Path}
 }

--- a/ImportExcel.psm1
+++ b/ImportExcel.psm1
@@ -13,207 +13,207 @@ Add-Type -Path "$($PSScriptRoot)\EPPlus.dll"
 . $PSScriptRoot\Pivot.ps1
 
 function Import-Excel {
-			[cmdletBinding(DefaultParameterSetName='SingleSheet')]
-				param(
-								[Alias('FullName')]
-								[Parameter(ValueFromPipelineByPropertyName=$true, ValueFromPipeline=$true, Mandatory=$true,position=0)]
-								$Path,
-								[Parameter(ParameterSetName='SingleSheet')]
-								[Alias('Sheet')]
-								$WorkSheetname=1,
-								[int]$HeaderRow=1,
-								[string[]]$Header,
-								[switch]$NoHeader,
-								[parameter(ParameterSetName='AllSheets')]
-								[Alias('AllSheets')]
-								[switch]$AllWorkSheets
-				)
+            [cmdletBinding(DefaultParameterSetName='SingleSheet')]
+                param(
+                                [Alias('FullName')]
+                                [Parameter(ValueFromPipelineByPropertyName=$true, ValueFromPipeline=$true, Mandatory=$true,position=0)]
+                                $Path,
+                                [Parameter(ParameterSetName='SingleSheet')]
+                                [Alias('Sheet')]
+                                $WorkSheetname=1,
+                                [int]$HeaderRow=1,
+                                [string[]]$Header,
+                                [switch]$NoHeader,
+                                [parameter(ParameterSetName='AllSheets')]
+                                [Alias('AllSheets')]
+                                [switch]$AllWorkSheets
+                )
 
-				Process {
+                Process {
 
-								$Path = (Resolve-Path $Path).Path
-								write-debug "target excel file $Path"
+                                $Path = (Resolve-Path $Path).Path
+                                write-debug "target excel file $Path"
 
-								$stream = New-Object -TypeName System.IO.FileStream -ArgumentList $Path,'Open','Read','ReadWrite'
-								$xl = New-Object -TypeName OfficeOpenXml.ExcelPackage -ArgumentList $stream
+                                $stream = New-Object -TypeName System.IO.FileStream -ArgumentList $Path,'Open','Read','ReadWrite'
+                                $xl = New-Object -TypeName OfficeOpenXml.ExcelPackage -ArgumentList $stream
 
-								$workbook  = $xl.Workbook
-								if($AllWorkSheets) {
-									Write-Debug "Processing All $($xl.Workbook.Worksheets.Count) WorkSheets of the Workbook"
-									$worksheetsName = $xl.Workbook.worksheets.name
-									$WorkBookObject = [ordered]@{}
-								}
-								else {
-									$worksheetsName = $WorkSheetname
-								}
+                                $workbook  = $xl.Workbook
+                                if($AllWorkSheets) {
+                                    Write-Debug "Processing All $($xl.Workbook.Worksheets.Count) WorkSheets of the Workbook"
+                                    $worksheetsName = $xl.Workbook.worksheets.name
+                                    $WorkBookObject = [ordered]@{}
+                                }
+                                else {
+                                    $worksheetsName = $WorkSheetname
+                                }
 
-								
-								foreach ($WorkSheetname in $worksheetsName)
-								{
-									Write-Debug "Processing Worksheet $WorkSheetName"
-									$worksheet=$workbook.Worksheets[$WorkSheetname]
-									$dimension=$worksheet.Dimension
 
-									$Rows=$dimension.Rows
-									$Columns=$dimension.Columns
-									$SheetRows = @()
+                                foreach ($WorkSheetname in $worksheetsName)
+                                {
+                                    Write-Debug "Processing Worksheet $WorkSheetName"
+                                    $worksheet=$workbook.Worksheets[$WorkSheetname]
+                                    $dimension=$worksheet.Dimension
 
-									if($NoHeader) {
-												foreach ($Row in 0..($Rows-1)) {
-																$newRow = [Ordered]@{}
-																foreach ($Column in 0..($Columns-1)) {
-																				$propertyName = "P$($Column+1)"
-																				$newRow.$propertyName = $worksheet.Cells[($Row+1),($Column+1)].Value
-																}
+                                    $Rows=$dimension.Rows
+                                    $Columns=$dimension.Columns
+                                    $SheetRows = @()
 
-													if($AllWorkSheets) { $SheetRows += [PSCustomObject]$newRow }
-													else {
-														[PSCustomObject]$newRow
-													}
-												}
-									} else {
-												if(!$Header) {
-																$Header = foreach ($Column in 1..$Columns) {
-																				$worksheet.Cells[$HeaderRow,$Column].Text
-																}
-												}
+                                    if($NoHeader) {
+                                                foreach ($Row in 0..($Rows-1)) {
+                                                                $newRow = [Ordered]@{}
+                                                                foreach ($Column in 0..($Columns-1)) {
+                                                                                $propertyName = "P$($Column+1)"
+                                                                                $newRow.$propertyName = $worksheet.Cells[($Row+1),($Column+1)].Value
+                                                                }
 
-												foreach ($Row in ($HeaderRow+1)..$Rows) {
-																$h=[Ordered]@{}
-																foreach ($Column in 0..($Columns-1)) {
-																				if($Header[$Column].Length -gt 0) {
-																								$Name    = $Header[$Column]
-																								$h.$Name = $worksheet.Cells[$Row,($Column+1)].Value
-																				}
-																}
-													if($AllWorkSheets) { $SheetRows += [PSCustomObject]$h }
-													else {
-														[PSCustomObject]$h
-													}
+                                                    if($AllWorkSheets) { $SheetRows += [PSCustomObject]$newRow }
+                                                    else {
+                                                        [PSCustomObject]$newRow
+                                                    }
+                                                }
+                                    } else {
+                                                if(!$Header) {
+                                                                $Header = foreach ($Column in 1..$Columns) {
+                                                                                $worksheet.Cells[$HeaderRow,$Column].Text
+                                                                }
+                                                }
+
+                                                foreach ($Row in ($HeaderRow+1)..$Rows) {
+                                                                $h=[Ordered]@{}
+                                                                foreach ($Column in 0..($Columns-1)) {
+                                                                                if($Header[$Column].Length -gt 0) {
+                                                                                                $Name    = $Header[$Column]
+                                                                                                $h.$Name = $worksheet.Cells[$Row,($Column+1)].Value
+                                                                                }
+                                                                }
+                                                    if($AllWorkSheets) { $SheetRows += [PSCustomObject]$h }
+                                                    else {
+                                                        [PSCustomObject]$h
+                                                    }
 																
-												}
-									}
-									if($AllWorkSheets) {
-										Write-Debug "Adding worksheet object $WorkSheetName to Workbook PSobject"
-										$WorkBookObject.add($WorkSheetname,$SheetRows);
-									}
-								}
-								if($AllWorkSheets) {
-									Write-Debug 'Writing the WorkbookObject to the Pipeline'
-									[PSCustomObject]$WorkBookObject
-								}
-								$stream.Close()
-								$stream.Dispose()
-								$xl.Dispose()
-								$xl = $null
-				}
+                                                }
+                                    }
+                                    if($AllWorkSheets) {
+                                        Write-Debug "Adding worksheet object $WorkSheetName to Workbook PSobject"
+                                        $WorkBookObject.add($WorkSheetname,$SheetRows);
+                                    }
+                                }
+                                if($AllWorkSheets) {
+                                    Write-Debug 'Writing the WorkbookObject to the Pipeline'
+                                    [PSCustomObject]$WorkBookObject
+                                }
+                                $stream.Close()
+                                $stream.Dispose()
+                                $xl.Dispose()
+                                $xl = $null
+                }
 }
 
 function Add-WorkSheet {
-				param(
-								#TODO Use parametersets to allow a workbook to be passed instead of a package
-								[Parameter(Mandatory=$true, ValueFromPipeline=$true)]
-								[OfficeOpenXml.ExcelPackage] $ExcelPackage,
-								[Parameter(Mandatory=$true)]
-								[string] $WorkSheetname,
-								[Switch] $NoClobber
-				)
+                param(
+                                #TODO Use parametersets to allow a workbook to be passed instead of a package
+                                [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
+                                [OfficeOpenXml.ExcelPackage] $ExcelPackage,
+                                [Parameter(Mandatory=$true)]
+                                [string] $WorkSheetname,
+                                [Switch] $NoClobber
+                )
 
-				$ws = $ExcelPackage.Workbook.Worksheets[$WorkSheetname]
+                $ws = $ExcelPackage.Workbook.Worksheets[$WorkSheetname]
 
-				if(!$ws) {
-								$ws=$ExcelPackage.Workbook.Worksheets.Add($WorkSheetname)
-				}
+                if(!$ws) {
+                                $ws=$ExcelPackage.Workbook.Worksheets.Add($WorkSheetname)
+                }
 
-				return $ws
+                return $ws
 }
 
 function ConvertFrom-ExcelSheet {
-				<#
-								.Synopsis
-								Reads an Excel file an converts the data to a delimited text file
+                <#
+                                .Synopsis
+                                Reads an Excel file an converts the data to a delimited text file
 
-								.Example
-								ConvertFrom-ExcelSheet .\TestSheets.xlsx .\data
-								Reads each sheet in TestSheets.xlsx and outputs it to the data directory as the sheet name with the extension .txt
+                                .Example
+                                ConvertFrom-ExcelSheet .\TestSheets.xlsx .\data
+                                Reads each sheet in TestSheets.xlsx and outputs it to the data directory as the sheet name with the extension .txt
 
-								.Example
-								ConvertFrom-ExcelSheet .\TestSheets.xlsx .\data sheet?0
-								Reads and outputs sheets like Sheet10 and Sheet20 form TestSheets.xlsx and outputs it to the data directory as the sheet name with the extension .txt
-				#>
+                                .Example
+                                ConvertFrom-ExcelSheet .\TestSheets.xlsx .\data sheet?0
+                                Reads and outputs sheets like Sheet10 and Sheet20 form TestSheets.xlsx and outputs it to the data directory as the sheet name with the extension .txt
+                #>
 
-				[CmdletBinding()]
-				param
-				(
-								[Alias('FullName')]
-								[Parameter(Mandatory = $true)]
-								[String]
-								$Path,
-								[String]
-								$OutputPath = '.\',
-								[String]
-								$SheetName='*',
-								[ValidateSet('ASCII', 'BigEndianUniCode','Default','OEM','UniCode','UTF32','UTF7','UTF8')]
-								[string]
-								$Encoding = 'UTF8',
-								[ValidateSet('.txt', '.log','.csv')]
-								[string]
-								$Extension = '.csv',
-								[ValidateSet(';', ',')]
-								[string]
-								$Delimiter = ';'
-				)
+                [CmdletBinding()]
+                param
+                (
+                                [Alias('FullName')]
+                                [Parameter(Mandatory = $true)]
+                                [String]
+                                $Path,
+                                [String]
+                                $OutputPath = '.\',
+                                [String]
+                                $SheetName='*',
+                                [ValidateSet('ASCII', 'BigEndianUniCode','Default','OEM','UniCode','UTF32','UTF7','UTF8')]
+                                [string]
+                                $Encoding = 'UTF8',
+                                [ValidateSet('.txt', '.log','.csv')]
+                                [string]
+                                $Extension = '.csv',
+                                [ValidateSet(';', ',')]
+                                [string]
+                                $Delimiter = ';'
+                )
 
-				$Path = (Resolve-Path $Path).Path
-				$stream = New-Object -TypeName System.IO.FileStream -ArgumentList $Path,'Open','Read','ReadWrite'
-				$xl = New-Object -TypeName OfficeOpenXml.ExcelPackage -ArgumentList $stream
-				$workbook = $xl.Workbook
+                $Path = (Resolve-Path $Path).Path
+                $stream = New-Object -TypeName System.IO.FileStream -ArgumentList $Path,'Open','Read','ReadWrite'
+                $xl = New-Object -TypeName OfficeOpenXml.ExcelPackage -ArgumentList $stream
+                $workbook = $xl.Workbook
 
-				$targetSheets = $workbook.Worksheets | Where {$_.Name -like $SheetName}
+                $targetSheets = $workbook.Worksheets | Where {$_.Name -like $SheetName}
 
-				$params = @{} + $PSBoundParameters
-				$params.Remove('OutputPath')
-				$params.Remove('SheetName')
-				$params.Remove('Extension')
-				$params.NoTypeInformation = $true
+                $params = @{} + $PSBoundParameters
+                $params.Remove('OutputPath')
+                $params.Remove('SheetName')
+                $params.Remove('Extension')
+                $params.NoTypeInformation = $true
 
-				Foreach ($sheet in $targetSheets)
-				{
-								Write-Verbose "Exporting sheet: $($sheet.Name)"
+                Foreach ($sheet in $targetSheets)
+                {
+                                Write-Verbose "Exporting sheet: $($sheet.Name)"
 
-								$params.Path = "$OutputPath\$($Sheet.Name)$Extension"
+                                $params.Path = "$OutputPath\$($Sheet.Name)$Extension"
 
-								Import-Excel $Path -Sheet $($sheet.Name) | Export-Csv @params
-				}
+                                Import-Excel $Path -Sheet $($sheet.Name) | Export-Csv @params
+                }
 
-				$stream.Close()
-				$stream.Dispose()
-				$xl.Dispose()
+                $stream.Close()
+                $stream.Dispose()
+                $xl.Dispose()
 }
 
 function Export-MultipleExcelSheets {
-				param(
-								[Parameter(Mandatory=$true)]
-								$Path,
-								[Parameter(Mandatory=$true)]
-								[hashtable]$InfoMap,
-								[string]$Password,
-								[Switch]$Show,
-								[Switch]$AutoSize
-				)
+                param(
+                                [Parameter(Mandatory=$true)]
+                                $Path,
+                                [Parameter(Mandatory=$true)]
+                                [hashtable]$InfoMap,
+                                [string]$Password,
+                                [Switch]$Show,
+                                [Switch]$AutoSize
+                )
 
-				$parameters = @{}+$PSBoundParameters
-				$parameters.Remove('InfoMap')
-				$parameters.Remove('Show')
+                $parameters = @{}+$PSBoundParameters
+                $parameters.Remove('InfoMap')
+                $parameters.Remove('Show')
 
-				$parameters.Path = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Path)
+                $parameters.Path = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Path)
 
-				foreach ($entry in $InfoMap.GetEnumerator()) {
-								Write-Progress -Activity 'Exporting' -Status "$($entry.Key)"
-								$parameters.WorkSheetname=$entry.Key
+                foreach ($entry in $InfoMap.GetEnumerator()) {
+                                Write-Progress -Activity 'Exporting' -Status "$($entry.Key)"
+                                $parameters.WorkSheetname=$entry.Key
 
-								& $entry.Value | Export-Excel @parameters
-				}
+                                & $entry.Value | Export-Excel @parameters
+                }
 
-				if($Show) {Invoke-Item $Path}
+                if($Show) {Invoke-Item $Path}
 }

--- a/ImportExcel.psm1
+++ b/ImportExcel.psm1
@@ -13,174 +13,207 @@ Add-Type -Path "$($PSScriptRoot)\EPPlus.dll"
 . $PSScriptRoot\Pivot.ps1
 
 function Import-Excel {
-    param(
-        [Alias("FullName")]
-        [Parameter(ValueFromPipelineByPropertyName=$true, ValueFromPipeline=$true, Mandatory=$true)]
-        $Path,
-        [Alias("Sheet")]
-        $WorkSheetname=1,
-        [int]$HeaderRow=1,
-        [string[]]$Header,
-        [switch]$NoHeader
-    )
+			[cmdletBinding(DefaultParameterSetName='SingleSheet')]
+				param(
+								[Alias('FullName')]
+								[Parameter(ValueFromPipelineByPropertyName=$true, ValueFromPipeline=$true, Mandatory=$true,position=0)]
+								$Path,
+								[Parameter(ParameterSetName='SingleSheet')]
+								[Alias('Sheet')]
+								$WorkSheetname=1,
+								[int]$HeaderRow=1,
+								[string[]]$Header,
+								[switch]$NoHeader,
+								[parameter(ParameterSetName='AllSheets')]
+								[Alias('AllSheets')]
+								[switch]$AllWorkSheets
+				)
 
-    Process {
+				Process {
 
-        $Path = (Resolve-Path $Path).Path
-        write-debug "target excel file $Path"
+								$Path = (Resolve-Path $Path).Path
+								write-debug "target excel file $Path"
 
-        $stream = New-Object -TypeName System.IO.FileStream -ArgumentList $Path,"Open","Read","ReadWrite"
-        $xl = New-Object -TypeName OfficeOpenXml.ExcelPackage -ArgumentList $stream
+								$stream = New-Object -TypeName System.IO.FileStream -ArgumentList $Path,'Open','Read','ReadWrite'
+								$xl = New-Object -TypeName OfficeOpenXml.ExcelPackage -ArgumentList $stream
 
-        $workbook  = $xl.Workbook
+								$workbook  = $xl.Workbook
+								if($AllWorkSheets) {
+									Write-Debug "Processing All $($xl.Workbook.Worksheets.Count) WorkSheets of the Workbook"
+									$worksheetsName = $xl.Workbook.worksheets.name
+									$WorkBookObject = [ordered]@{}
+								}
+								else {
+									$worksheetsName = $WorkSheetname
+								}
 
-        $worksheet=$workbook.Worksheets[$WorkSheetname]
-        $dimension=$worksheet.Dimension
+								
+								foreach ($WorkSheetname in $worksheetsName)
+								{
+									Write-Debug "Processing Worksheet $WorkSheetName"
+									$worksheet=$workbook.Worksheets[$WorkSheetname]
+									$dimension=$worksheet.Dimension
 
-        $Rows=$dimension.Rows
-        $Columns=$dimension.Columns
+									$Rows=$dimension.Rows
+									$Columns=$dimension.Columns
+									$SheetRows = @()
 
-        if($NoHeader) {
-            foreach ($Row in 0..($Rows-1)) {
-                $newRow = [Ordered]@{}
-                foreach ($Column in 0..($Columns-1)) {
-                    $propertyName = "P$($Column+1)"
-                    $newRow.$propertyName = $worksheet.Cells[($Row+1),($Column+1)].Value
-                }
+									if($NoHeader) {
+												foreach ($Row in 0..($Rows-1)) {
+																$newRow = [Ordered]@{}
+																foreach ($Column in 0..($Columns-1)) {
+																				$propertyName = "P$($Column+1)"
+																				$newRow.$propertyName = $worksheet.Cells[($Row+1),($Column+1)].Value
+																}
 
-                [PSCustomObject]$newRow
-            }
-        } else {
-            if(!$Header) {
-                $Header = foreach ($Column in 1..$Columns) {
-                    $worksheet.Cells[$HeaderRow,$Column].Text
-                }
-            }
+													if($AllWorkSheets) { $SheetRows += [PSCustomObject]$newRow }
+													else {
+														[PSCustomObject]$newRow
+													}
+												}
+									} else {
+												if(!$Header) {
+																$Header = foreach ($Column in 1..$Columns) {
+																				$worksheet.Cells[$HeaderRow,$Column].Text
+																}
+												}
 
-            foreach ($Row in ($HeaderRow+1)..$Rows) {
-                $h=[Ordered]@{}
-                foreach ($Column in 0..($Columns-1)) {
-                    if($Header[$Column].Length -gt 0) {
-                        $Name    = $Header[$Column]
-                        $h.$Name = $worksheet.Cells[$Row,($Column+1)].Value
-                    }
-                }
-                [PSCustomObject]$h
-            }
-        }
-
-        $stream.Close()
-        $stream.Dispose()
-        $xl.Dispose()
-        $xl = $null
-    }
+												foreach ($Row in ($HeaderRow+1)..$Rows) {
+																$h=[Ordered]@{}
+																foreach ($Column in 0..($Columns-1)) {
+																				if($Header[$Column].Length -gt 0) {
+																								$Name    = $Header[$Column]
+																								$h.$Name = $worksheet.Cells[$Row,($Column+1)].Value
+																				}
+																}
+													if($AllWorkSheets) { $SheetRows += [PSCustomObject]$h }
+													else {
+														[PSCustomObject]$h
+													}
+																
+												}
+									}
+									if($AllWorkSheets) {
+										Write-Debug "Adding worksheet object $WorkSheetName to Workbook PSobject"
+										$WorkBookObject.add($WorkSheetname,$SheetRows);
+									}
+								}
+								if($AllWorkSheets) {
+									Write-Debug 'Writing the WorkbookObject to the Pipeline'
+									[PSCustomObject]$WorkBookObject
+								}
+								$stream.Close()
+								$stream.Dispose()
+								$xl.Dispose()
+								$xl = $null
+				}
 }
 
 function Add-WorkSheet {
-    param(
-        #TODO Use parametersets to allow a workbook to be passed instead of a package
-        [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
-        [OfficeOpenXml.ExcelPackage] $ExcelPackage,
-        [Parameter(Mandatory=$true)]
-        [string] $WorkSheetname,
-        [Switch] $NoClobber
-    )
+				param(
+								#TODO Use parametersets to allow a workbook to be passed instead of a package
+								[Parameter(Mandatory=$true, ValueFromPipeline=$true)]
+								[OfficeOpenXml.ExcelPackage] $ExcelPackage,
+								[Parameter(Mandatory=$true)]
+								[string] $WorkSheetname,
+								[Switch] $NoClobber
+				)
 
-    $ws = $ExcelPackage.Workbook.Worksheets[$WorkSheetname]
+				$ws = $ExcelPackage.Workbook.Worksheets[$WorkSheetname]
 
-    if(!$ws) {
-        $ws=$ExcelPackage.Workbook.Worksheets.Add($WorkSheetname)
-    }
+				if(!$ws) {
+								$ws=$ExcelPackage.Workbook.Worksheets.Add($WorkSheetname)
+				}
 
-    return $ws
+				return $ws
 }
 
 function ConvertFrom-ExcelSheet {
-    <#
-        .Synopsis
-        Reads an Excel file an converts the data to a delimited text file
+				<#
+								.Synopsis
+								Reads an Excel file an converts the data to a delimited text file
 
-        .Example
-        ConvertFrom-ExcelSheet .\TestSheets.xlsx .\data
-        Reads each sheet in TestSheets.xlsx and outputs it to the data directory as the sheet name with the extension .txt
+								.Example
+								ConvertFrom-ExcelSheet .\TestSheets.xlsx .\data
+								Reads each sheet in TestSheets.xlsx and outputs it to the data directory as the sheet name with the extension .txt
 
-        .Example
-        ConvertFrom-ExcelSheet .\TestSheets.xlsx .\data sheet?0
-        Reads and outputs sheets like Sheet10 and Sheet20 form TestSheets.xlsx and outputs it to the data directory as the sheet name with the extension .txt
-    #>
+								.Example
+								ConvertFrom-ExcelSheet .\TestSheets.xlsx .\data sheet?0
+								Reads and outputs sheets like Sheet10 and Sheet20 form TestSheets.xlsx and outputs it to the data directory as the sheet name with the extension .txt
+				#>
 
-    [CmdletBinding()]
-    param
-    (
-        [Alias("FullName")]
-        [Parameter(Mandatory = $true)]
-        [String]
-        $Path,
-        [String]
-        $OutputPath = '.\',
-        [String]
-        $SheetName="*",
-        [ValidateSet('ASCII', 'BigEndianUniCode','Default','OEM','UniCode','UTF32','UTF7','UTF8')]
-        [string]
-        $Encoding = 'UTF8',
-        [ValidateSet('.txt', '.log','.csv')]
-        [string]
-        $Extension = '.csv',
-        [ValidateSet(';', ',')]
-        [string]
-        $Delimiter = ';'
-    )
+				[CmdletBinding()]
+				param
+				(
+								[Alias('FullName')]
+								[Parameter(Mandatory = $true)]
+								[String]
+								$Path,
+								[String]
+								$OutputPath = '.\',
+								[String]
+								$SheetName='*',
+								[ValidateSet('ASCII', 'BigEndianUniCode','Default','OEM','UniCode','UTF32','UTF7','UTF8')]
+								[string]
+								$Encoding = 'UTF8',
+								[ValidateSet('.txt', '.log','.csv')]
+								[string]
+								$Extension = '.csv',
+								[ValidateSet(';', ',')]
+								[string]
+								$Delimiter = ';'
+				)
 
-    $Path = (Resolve-Path $Path).Path
-    $stream = New-Object -TypeName System.IO.FileStream -ArgumentList $Path,"Open","Read","ReadWrite"
-    $xl = New-Object -TypeName OfficeOpenXml.ExcelPackage -ArgumentList $stream
-    $workbook = $xl.Workbook
+				$Path = (Resolve-Path $Path).Path
+				$stream = New-Object -TypeName System.IO.FileStream -ArgumentList $Path,'Open','Read','ReadWrite'
+				$xl = New-Object -TypeName OfficeOpenXml.ExcelPackage -ArgumentList $stream
+				$workbook = $xl.Workbook
 
-    $targetSheets = $workbook.Worksheets | Where {$_.Name -like $SheetName}
+				$targetSheets = $workbook.Worksheets | Where {$_.Name -like $SheetName}
 
-    $params = @{} + $PSBoundParameters
-    $params.Remove("OutputPath")
-    $params.Remove("SheetName")
-    $params.Remove('Extension')
-    $params.NoTypeInformation = $true
+				$params = @{} + $PSBoundParameters
+				$params.Remove('OutputPath')
+				$params.Remove('SheetName')
+				$params.Remove('Extension')
+				$params.NoTypeInformation = $true
 
-    Foreach ($sheet in $targetSheets)
-    {
-        Write-Verbose "Exporting sheet: $($sheet.Name)"
+				Foreach ($sheet in $targetSheets)
+				{
+								Write-Verbose "Exporting sheet: $($sheet.Name)"
 
-        $params.Path = "$OutputPath\$($Sheet.Name)$Extension"
+								$params.Path = "$OutputPath\$($Sheet.Name)$Extension"
 
-        Import-Excel $Path -Sheet $($sheet.Name) | Export-Csv @params
-    }
+								Import-Excel $Path -Sheet $($sheet.Name) | Export-Csv @params
+				}
 
-    $stream.Close()
-    $stream.Dispose()
-    $xl.Dispose()
+				$stream.Close()
+				$stream.Dispose()
+				$xl.Dispose()
 }
 
 function Export-MultipleExcelSheets {
-    param(
-        [Parameter(Mandatory=$true)]
-        $Path,
-        [Parameter(Mandatory=$true)]
-        [hashtable]$InfoMap,
-        [string]$Password,
-        [Switch]$Show,
-        [Switch]$AutoSize
-    )
+				param(
+								[Parameter(Mandatory=$true)]
+								$Path,
+								[Parameter(Mandatory=$true)]
+								[hashtable]$InfoMap,
+								[string]$Password,
+								[Switch]$Show,
+								[Switch]$AutoSize
+				)
 
-    $parameters = @{}+$PSBoundParameters
-    $parameters.Remove("InfoMap")
-    $parameters.Remove("Show")
+				$parameters = @{}+$PSBoundParameters
+				$parameters.Remove('InfoMap')
+				$parameters.Remove('Show')
 
-    $parameters.Path = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Path)
+				$parameters.Path = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Path)
 
-    foreach ($entry in $InfoMap.GetEnumerator()) {
-        Write-Progress -Activity "Exporting" -Status "$($entry.Key)"
-        $parameters.WorkSheetname=$entry.Key
+				foreach ($entry in $InfoMap.GetEnumerator()) {
+								Write-Progress -Activity 'Exporting' -Status "$($entry.Key)"
+								$parameters.WorkSheetname=$entry.Key
 
-        & $entry.Value | Export-Excel @parameters
-    }
+								& $entry.Value | Export-Excel @parameters
+				}
 
-    if($Show) {Invoke-Item $Path}
+				if($Show) {Invoke-Item $Path}
 }


### PR DESCRIPTION
I Needed to be able to import a full Workbook instead of a single sheet, if possible without iterating through worksheets until it failed.
To avoid breaking backward compatibility I implemented the option as another parameter set, while setting the default parameter set as the original function syntax.

I think the form
```Powershell
if($AllWorkSheets) { ... } 
else { ... }
```
is clearer/less verbose than 
```Powershell
switch ($PsCmdlet.ParameterSetName) {
         'AllSheets' { ... }
         'SingleSheet' { ... }
}
```

Let me know if you're happy with this quick hack, or if you have any suggestion.