### PR TITLE
Allow ordered dictionary for PivotData

### DIFF
--- a/Export-Excel.ps1
+++ b/Export-Excel.ps1
@@ -269,7 +269,7 @@ function Export-Excel {
             }
 
             if($PivotData) {
-                if($PivotData -is [hashtable]) {
+                if($PivotData -is [hashtable] -or $PivotData -is [System.Collections.Specialized.OrderedDictionary]) {
                     $PivotData.Keys | % {
                         $df=$pivotTable.DataFields.Add($pivotTable.Fields[$_])
                         $df.Function = $PivotData.$_


### PR DESCRIPTION
Adjust code for -PivotData to allow use of an ordered dictionary

This allows users to maintain the order of their PivotData fields when exporting to Excel if they pass a hashtable of the format:  `[ordered]@{}`

A standard PowerShell hashtable does not retain the order of the keys when you enumerate it.