### PR TITLE
Added ValidateScript block to Path parameter for Import-Excel

### DIFF
--- a/ImportExcel.psm1
+++ b/ImportExcel.psm1
@@ -29,6 +29,7 @@ function Import-Excel {
     param(
         [Alias("FullName")]
         [Parameter(ValueFromPipelineByPropertyName=$true, ValueFromPipeline=$true, Mandatory=$true)]
+        [ValidateScript({ Test-Path $_ -PathType Leaf })]
         $Path,
         [Alias("Sheet")]
         $WorkSheetname=1,


### PR DESCRIPTION
Currently, when you give Import-Excel an invalid path you get:

Cannot convert argument "1", with value: "Open", for "FileStream" to type "System.IO.FileAccess": "Cannot convert value "Open" to type "System.IO.FileAccess". Error: "Unable to match the identifier name Open to a valid enumerator name. Specify one of the following enumerator names and try again:
Read, Write, ReadWrite""

Took me a while to troubleshoot that down to me being stupid and not giving it a valid path.  This will make the Cmdlet error out before it ever runs.