### PR TITLE
Fix for #82: multiple series aren't supported in a single chart.

### DIFF
--- a/Export-Excel.ps1
+++ b/Export-Excel.ps1
@@ -356,7 +356,7 @@ function Export-Excel {
             $chart.SetPosition($chartDef.Row, $chartDef.RowOffsetPixels,$chartDef.Column, $chartDef.ColumnOffsetPixels)
             $chart.SetSize($chartDef.Width, $chartDef.Height)
 
-            $chartDefCount = @($chartDef.XRange).Count
+            $chartDefCount = @($chartDef.YRange).Count
             if($chartDefCount -eq 1) {
                 $Series=$chart.Series.Add($chartDef.YRange, $chartDef.XRange)
                 $Series.Header = $chartDef.Header


### PR DESCRIPTION
This fixes #82 

Now a list of ranges passed as YRange results in multiple series in a single chart.