### PR TITLE
Added support for PowerShell version checks.

### DIFF
--- a/ImportExcel.psm1
+++ b/ImportExcel.psm1
@@ -16,7 +16,13 @@ Add-Type -Path "$($PSScriptRoot)\EPPlus.dll"
 . $PSScriptRoot\Get-HtmlTable.ps1
 . $PSScriptRoot\Import-Html.ps1
 . $PSScriptRoot\Get-Range.ps1
-. $PSScriptRoot\plot.ps1
+
+if (& $PSScriptRoot\TestPsVersion.ps1 5) {
+    . $PSScriptRoot\plot.ps1
+}
+else {
+    Write-Warning "PowerShell 5 is required for fluent plot api. Skipping plot.ps1."
+}
 
 function New-Plot { 
     [OutputType([PSPlot])]

--- a/TestPsVersion.ps1
+++ b/TestPsVersion.ps1
@@ -1,0 +1,31 @@
+<#
+.SYNOPSIS
+
+Tests for a particular PowerShell version.
+
+.PARAMETER Version
+
+The version to test for.
+
+.EXAMPLE
+
+PS> & .\TestPsVersion.ps1 4
+
+This will return true if the PowerShell version is 4 or greater.
+
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$true)]
+    [double]$Version
+)
+Set-StrictMode -Version Latest
+$psver = $PSVersionTable.PSVersion
+$check = $null
+if ($psver.Major -ne $null) {
+    $check = $psver.Major
+}
+else {
+    $check = $psver
+}
+([double]"$check") -ge $Version


### PR DESCRIPTION
Previously, when the ImportExcel module was imported into a PowerShell 4
session, the import would fail. This functionality solves that problem.
To confirm this, cd into ImportExcel and run 'Import-Module .\ -Force'.
If you are running in a PowerShell 4 session, then a warning will be
displayed.