### PR TITLE
Made test independent of module path.

### DIFF
--- a/Export-Excel.Tests.ps1
+++ b/Export-Excel.Tests.ps1
@@ -1,6 +1,6 @@
 # Contributed by https://github.com/W1M0R
 
-Import-Module ImportExcel -Force 
+Import-Module $PSScriptRoot -Force -Scope Global
 
 function New-TestWorkbook {
     $testWorkbook = "$($PSScriptRoot)\test.xlsx"


### PR DESCRIPTION
By specifying the path, instead of the module name, the pester test can run without having the module installed into the global/user module path.
