### PR TITLE
Import excel added parameter 'Password'

### DIFF
--- a/ImportExcel.psd1
+++ b/ImportExcel.psd1
@@ -4,7 +4,7 @@
 RootModule = 'ImportExcel.psm1'
 
 # Version number of this module.
-ModuleVersion = '4.0.0'
+ModuleVersion = '4.0.1'
 
 # ID used to uniquely identify this module
 GUID = '60dd4136-feff-401a-ba27-a84458c57ede'

--- a/ImportExcel.psm1
+++ b/ImportExcel.psm1
@@ -80,6 +80,9 @@ Function Import-Excel {
 
         When the parameters ‘-NoHeader’ and ‘-HeaderName’ are not provided, this row will contain the column headers that will be used as property names. When one of both parameters are provided, the property names are automatically created and this row will be treated as a regular row containing data.
 
+    .PARAMETER Password
+        Accepts a string that will be used to open a password protected Excel file.
+
     .EXAMPLE
         Import data from an Excel worksheet. One object is created for each row. The property names of the objects consist of the column names defined in the first row. In case a column doesn’t have a column header (usually in row 1 when ‘-StartRow’ is not used), then the unnamed columns will be skipped and the data in those columns will not be imported.
 

--- a/ImportExcel.psm1
+++ b/ImportExcel.psm1
@@ -75,13 +75,13 @@ Function Import-Excel {
 
         This switch is best used when you want to import the complete worksheet ‘as is’ and are not concerned with the property names.
 
-    .PARAMETER TopRow
-        The row from where we start to import data, all rows above the TopRow are disregarded. By default this is the first row. 
+    .PARAMETER StartRow
+        The row from where we start to import data, all rows above the StartRow are disregarded. By default this is the first row. 
 
         When the parameters ‘-NoHeader’ and ‘-HeaderName’ are not provided, this row will contain the column headers that will be used as property names. When one of both parameters are provided, the property names are automatically created and this row will be treated as a regular row containing data.
 
     .EXAMPLE
-        Import data from an Excel worksheet. One object is created for each row. The property names of the objects consist of the column names defined in the first row. In case a column doesn’t have a column header (usually in row 1 when ‘-TopRow’ is not used), then the unnamed columns will be skipped and the data in those columns will not be imported.
+        Import data from an Excel worksheet. One object is created for each row. The property names of the objects consist of the column names defined in the first row. In case a column doesn’t have a column header (usually in row 1 when ‘-StartRow’ is not used), then the unnamed columns will be skipped and the data in those columns will not be imported.
 
         ----------------------------------------------
         | File: Movies.xlsx     -      Sheet: Actors |
@@ -208,36 +208,25 @@ Function Import-Excel {
         |3     Jean-Claude               Vandamme     Brussels   |
         ----------------------------------------------------------
 
-        PS C:\> Import-Excel -Path 'C:\Movies.xlsx' -WorkSheetname Actors -DataOnly -HeaderName 'FirstName', 'SecondName', 'City' –TopRow 2
+        PS C:\> Import-Excel -Path 'C:\Movies.xlsx' -WorkSheetname Actors -DataOnly -HeaderName 'FirstName', 'SecondName', 'City' –StartRow 2
          
         FirstName : Jean-Claude
         SecondName: Vandamme
         City      : Brussels
 
-        Notice that only 1 object is imported with only 3 properties. Column B and row 2 are empty and have been disregarded by using the switch '-DataOnly'. The property names have been named with the values provided with the parameter '-HeaderName'. Row number 1 with ‘Chuck Norris’ has not been imported, because we started the import from row 2 with the parameter ‘-TopRow 2’.
+        Notice that only 1 object is imported with only 3 properties. Column B and row 2 are empty and have been disregarded by using the switch '-DataOnly'. The property names have been named with the values provided with the parameter '-HeaderName'. Row number 1 with ‘Chuck Norris’ has not been imported, because we started the import from row 2 with the parameter ‘-StartRow 2’.
             
     .LINK
         https://github.com/dfinke/ImportExcel
 
     .NOTES
-        2017/08/16 Added parameter sets for proper parameter validation and to make sure '-NoHeader' and '-HeaderRow' aren't used together
-                   Added try/catch clause, CmdLetBinding and verbose messages
-                   Renamed 'HeaderRow' to 'TopRow' to avoid confusion with other parameters
-                   Renamed '-Header' to '-HeaderName'
-                   Added test for duplicate property names
-                   Added test for empty worksheet
-                   Added test for no data after TopRow
-                   Fixed incorrect import when there's no value in the first column
-                   Fixed values being imported under the wrong property name in case one 
-                   Fixed incorrect import in case column A is empty and B and C not ( '$Worksheet.Dimension.Columns' is unreliable because it will say 2 columns are in use while it should say 3).
-                   (Ex. Add data in cell B2 and C2, use the '-NoHeader' switch, notice P1 and P2 are incorrectly blanc.)
     #>
 
     [CmdLetBinding(DefaultParameterSetName)]
     Param (
         [Alias('FullName')]
         [Parameter(ValueFromPipelineByPropertyName, ValueFromPipeline, Position=0, Mandatory)]
-        [ValidateScript({Test-Path -Path $_ -PathType Leaf})]
+        [ValidateScript({(Test-Path -Path $_ -PathType Leaf) -and ($_ -match '.xls$|.xlsx$')})]
         [String]$Path,
         [Alias('Sheet')]
         [Parameter(Position=1)]
@@ -247,10 +236,12 @@ Function Import-Excel {
         [String[]]$HeaderName,
         [Parameter(ParameterSetName='C', Mandatory)]
         [Switch]$NoHeader,
-        [Alias('HeaderRow')]
+        [Alias('HeaderRow','TopRow')]
         [ValidateRange(1, 9999)]
-        [Int]$TopRow,
-        [Switch]$DataOnly
+        [Int]$StartRow,
+        [Switch]$DataOnly,
+        [ValidateNotNullOrEmpty()]
+        [String]$Password
     )
 
     Begin {
@@ -285,7 +276,7 @@ Function Import-Excel {
                 [Parameter(Mandatory)]
                 [Int[]]$Columns,
                 [Parameter(Mandatory)]
-                [Int]$TopRow
+                [Int]$StartRow
             )
             
             Try {
@@ -304,12 +295,12 @@ Function Import-Excel {
                     }
                 }
                 else {
-                    if ($TopRow -eq 0) {
+                    if ($StartRow -eq 0) {
                         throw 'The top row can never be equal to 0 when we need to retrieve headers from the worksheet.'
                     }
 
                     foreach ($C in $Columns) {
-                        $Worksheet.Cells[$TopRow,$C] | where {$_.Value} | Select-Object @{N='Column'; E={$C}}, Value
+                        $Worksheet.Cells[$StartRow,$C] | where {$_.Value} | Select-Object @{N='Column'; E={$C}}, Value
                     }
                 }
             }
@@ -321,11 +312,26 @@ Function Import-Excel {
 
     Process {
         Try {
+            #region Open file
             $Path = (Resolve-Path $Path).ProviderPath
             Write-Verbose "Import Excel workbook '$Path' with worksheet '$Worksheetname'"
 
             $Stream = New-Object -TypeName System.IO.FileStream -ArgumentList $Path, 'Open', 'Read', 'ReadWrite'
-            $Excel = New-Object -TypeName OfficeOpenXml.ExcelPackage -ArgumentList $Stream
+
+            if ($Password) {
+                $Excel = New-Object -TypeName OfficeOpenXml.ExcelPackage
+
+	            Try {
+		            $Excel.Load($Stream,$Password)
+	            }
+	            Catch {
+		            throw "Password '$Password' is not correct."
+	            }
+            }
+            else {
+                $Excel = New-Object -TypeName OfficeOpenXml.ExcelPackage -ArgumentList $Stream
+            }
+            #endregion
 
             #region Select worksheet
             if ($WorksheetName) {
@@ -339,13 +345,13 @@ Function Import-Excel {
             #endregion
             
             #region Set the top row
-            if (((-not ($NoHeader -or $HeaderName)) -and ($TopRow -eq 0))) {
-                $TopRow = 1
+            if (((-not ($NoHeader -or $HeaderName)) -and ($StartRow -eq 0))) {
+                $StartRow = 1
             }
             #endregion
 
-            if (-not ($AllCells = $Worksheet.Cells | where {($_.Start.Row -ge $TopRow)})) {
-                Write-Warning "Worksheet '$WorksheetName' in workbook '$Path' is empty after TopRow '$TopRow'"
+            if (-not ($AllCells = $Worksheet.Cells | where {($_.Start.Row -ge $StartRow)})) {
+                Write-Warning "Worksheet '$WorksheetName' in workbook '$Path' is empty after StartRow '$StartRow'"
             }
             else {
                 #region Get rows and columns
@@ -360,17 +366,17 @@ Function Import-Excel {
                     $Columns = 1..$LastColumn
 
                     $LastRow = $AllCells.Start.Row | Sort-Object -Unique | Select-Object -Last 1
-                    $Rows = $TopRow..$LastRow | where {($_ -ge $TopRow) -and ($_ -gt 0)}
+                    $Rows = $StartRow..$LastRow | where {($_ -ge $StartRow) -and ($_ -gt 0)}
                 }
                 #endregion
 
                 #region Create property names
-                if ((-not $Columns) -or (-not ($PropertyNames = Get-PropertyNames -Columns $Columns -TopRow $TopRow))) {
-                    throw "No column headers found on top row '$TopRow'. If column headers in the worksheet are not a requirement then please use the '-NoHeader' or '-HeaderName' parameter."
+                if ((-not $Columns) -or (-not ($PropertyNames = Get-PropertyNames -Columns $Columns -StartRow $StartRow))) {
+                    throw "No column headers found on top row '$StartRow'. If column headers in the worksheet are not a requirement then please use the '-NoHeader' or '-HeaderName' parameter."
                 }
 
                 if ($Duplicates = $PropertyNames | Group-Object Value | where Count -GE 2) {
-                    throw "Duplicate column headers found on row '$TopRow' in columns '$($Duplicates.Group.Column)'. Column headers must be unique, if this is not a requirement please use the '-NoHeader' or '-HeaderName' parameter."
+                    throw "Duplicate column headers found on row '$StartRow' in columns '$($Duplicates.Group.Column)'. Column headers must be unique, if this is not a requirement please use the '-NoHeader' or '-HeaderName' parameter."
                 }
                 #endregion
 
@@ -383,12 +389,12 @@ Function Import-Excel {
 
                 #region Filter out the top row when it contains column headers
                 if (-not ($NoHeader -or $HeaderName)) {
-                    $Rows = $Rows | where {$_ -gt $TopRow}
+                    $Rows = $Rows | where {$_ -gt $StartRow}
                 }
                 #endregion
 
                 if (-not $Rows) {
-                    Write-Warning "Worksheet '$WorksheetName' in workbook '$Path' contains no data in the rows after top row '$TopRow'"
+                    Write-Warning "Worksheet '$WorksheetName' in workbook '$Path' contains no data in the rows after top row '$StartRow'"
                 }
                 else {
                     #region Create one object per row

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ iex (new-object System.Net.WebClient).DownloadString('https://raw.github.com/dfi
 
 Special thanks to [robinmalik](https://github.com/robinmalik) for providing us with [the code](https://github.com/dfinke/ImportExcel/issues/174) to implement this new feature. A high five to [DarkLite1](https://github.com/DarkLite1) for the implementation.
 
-#### 9/12/2017 (Version 4.0)
+#### 9/12/2017 (Version 4.0.0)
 
 Super thanks and hat tip to [DarkLite1](https://github.com/DarkLite1). There is now a new and improved `Import-Excel`, not only in functionality, but also improved readability, examples and more. Not only that, he's been running it in production in his company for a number of weeks!
 

--- a/README.md
+++ b/README.md
@@ -27,15 +27,22 @@ iex (new-object System.Net.WebClient).DownloadString('https://raw.github.com/dfi
 ```
 
 # What's new
-#### 9/12/2017
-Version 4.0 released.
+#### 9/28/2017 (Version 4.0.1)
+- Added a new parameter called `Password` to import password protected files
+- Added even more `Pester` tests for a more robust and bug free module
+- Renamed parameter 'TopRow' to 'StartRow'
+  This allows us to be more concise when new parameters ('StartColumn', ..) will be added in the future Your code will not break after the update, because we added an alias for backward compatibility
+
+Special thanks to [robinmalik](https://github.com/robinmalik) for providing us with [the code](https://github.com/dfinke/ImportExcel/issues/174) to implement this new feature. A high five to [DarkLite1](https://github.com/DarkLite1) for the implementation.
+
+#### 9/12/2017 (Version 4.0)
 
 Super thanks and hat tip to [DarkLite1](https://github.com/DarkLite1). There is now a new and improved `Import-Excel`, not only in functionality, but also improved readability, examples and more. Not only that, he's been running it in production in his company for a number of weeks!
 
 *Added* `Update-FirstObjectProperties` Updates the first object to contain all the properties of the object with the most properties in the array. Check out the help.
 
 
-***Breaking Changes***: Due to a big portion of the code that is rewritten some slightly different behaviour can be expected from the `Import-Excel` function. This is especially true for importing empty Excel files with or without using the `TopRow` parameter. To make sure that your code is still valid, please check the examples in the help or the accompanying `Pester` test file.
+***Breaking Changes***: Due to a big portion of the code that is rewritten some slightly different behavior can be expected from the `Import-Excel` function. This is especially true for importing empty Excel files with or without using the `TopRow` parameter. To make sure that your code is still valid, please check the examples in the help or the accompanying `Pester` test file.
 
 
 Moving forward, we are planning to include automatic testing with the help of `Pester`, `Appveyor` and `Travis`. From now on any changes in the module will have to be accompanied by the corresponding `Pester` tests to avoid breakages of code and functionality. This is in preparation for new features coming down the road.


### PR DESCRIPTION
 **Bumped version to 4.0.1**
 - Renamed 'TopRow' to 'StartRow' and added alias
   (More concise with future parameter names like 'StartColumn')
 - Removed 'ChangeList' in 'Notes' as this is tracked in Git
 - Added parameter 'Password' to import password protected files
 - Added Pester tests for parameter aliasses and:
         - parameter 'Password'
         - parameter 'Path' validation for extensions '.xls' and '.xlsx'
         - 'HeaderName' witb blanks
 - Changed comments in Pester tests from '<# Comment #>' to '# Comment'
   (Easier to comment out a whole block of tests when performing a test on a specific piece of code)