### PR TITLE
Fix Bug. AutoFilter with TableName corrupted file

### DIFF
--- a/Export-Excel.ps1
+++ b/Export-Excel.ps1
@@ -194,7 +194,7 @@ Function Export-Excel {
             https://github.com/dfinke/ImportExcel
     #>
 
-    [CmdLetBinding()]
+    [CmdletBinding(DefaultParameterSetName='Default')]
     Param(
         $Path,
         [Parameter(ValueFromPipeline=$true)]
@@ -223,6 +223,7 @@ Function Export-Excel {
         [Switch]$FreezeFirstColumn,
         [Switch]$FreezeTopRowFirstColumn,
         [Int[]]$FreezePane,
+        [Parameter(ParameterSetName='Default')]
         [Switch]$AutoFilter,
         [Switch]$BoldTopRow,
         [Switch]$NoHeader,
@@ -240,8 +241,10 @@ Function Export-Excel {
             else {
                 $true
             }
-        })] 
+        })]
+        [Parameter(ParameterSetName='Table')]
         [String]$TableName,
+        [Parameter(ParameterSetName='Table')]
         [OfficeOpenXml.Table.TableStyles]$TableStyle = 'Medium6',
         [Object[]]$ExcelChartDefinition,
         [String[]]$HideSheet,
@@ -386,7 +389,10 @@ Function Export-Excel {
                 $Path = [System.IO.Path]::GetTempFileName() -replace '\.tmp','.xlsx'                
                 $Show = $true
                 $AutoSize = $true
-                $AutoFilter = $true
+                if (!$TableName)
+                {
+                    $AutoFilter = $true
+                }
             }
 
             $Path = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Path)

--- a/ImportExcel.psm1
+++ b/ImportExcel.psm1
@@ -30,8 +30,6 @@ if ($PSVersionTable.PSVersion.Major -ge 5) {
     . $PSScriptRoot\Plot.ps1
 
     Function New-Plot {
-        [OutputType([PSPlot])]
-        Param()
 
         [PSPlot]::new()
     }


### PR DESCRIPTION
Fix Bug, AutoFilter with TableName create corrupted Excel file.
https://github.com/dfinke/ImportExcel/issues/65
You now cannot set AutoFilter and TableName at the same time.
"-Now" will not auto add AutoFilter if TableName set.