### PR TITLE
EPPlus supports Range.Indent this adds support for it

### DIFF
--- a/SetFormat.ps1
+++ b/SetFormat.ps1
@@ -62,7 +62,10 @@ Function Set-Format {
         #Set cells to a fixed hieght  (rows or ranges only)
         [float]$Height,
         #Hide a row or column  (not a range)
-        [switch]$Hidden
+        [switch]$Hidden,
+        #Indent cells in range
+        [ValidateRange(0, 15)]
+        [int]$Indent
     )
     process {
         Foreach ($range in $Address) {
@@ -124,6 +127,7 @@ Function Set-Format {
                     $Range -is [OfficeOpenXml.ExcelColumn]  ) {$Range.Hidden = $True}
                 else {Write-Warning -Message ("Can hide a row or a column but not a {0} object" -f ($Range.GetType().name)) }
             }
+            if ($Indent) {$Range.Style.Indent = $Indent }
         }
     }
 }


### PR DESCRIPTION
This adds support for indenting ranges with Set-Format
EPPlus library already supports this with indenting values between 0-15.

This was my fist github pull request, hope that I made it right.


