### PR TITLE
 Fix for issue #359

### DIFF
--- a/Export-Excel.ps1
+++ b/Export-Excel.ps1
@@ -581,11 +581,11 @@
                 $ws.Cells[$headerRange].Value | foreach -Begin {$Script:header = @()} -Process {$Script:header += $_ }
                 #When creating a new file with Append, the row has to be set to the start row as no sheet exists yet to set a value from.
                 if ($ws.Dimension.Rows -eq $null) {
-					$row = $StartRow
-				} 
-				else {
-					$row = $ws.Dimension.Rows
-				}
+			$row = $StartRow
+		} 
+		else {
+			$row = $ws.Dimension.Rows
+		}
                 Write-Debug -Message ("Appending: headers are " + ($script:Header -join ", ") + "Start row $row")
             }
             elseif ($Title) {

--- a/Export-Excel.ps1
+++ b/Export-Excel.ps1
@@ -579,7 +579,13 @@
                 #$script:Header     = $ws.Cells[$headerrange].Value
                 #using a slightly odd syntax otherwise header ends up as a 2D array
                 $ws.Cells[$headerRange].Value | foreach -Begin {$Script:header = @()} -Process {$Script:header += $_ }
-                $row = $ws.Dimension.Rows
+                #When creating a new file with Append, the row has to be set to the start row as no sheet exists yet to set a value from.
+                if ($ws.Dimension.Rows -eq $null) {
+					$row = $StartRow
+				} 
+				else {
+					$row = $ws.Dimension.Rows
+				}
                 Write-Debug -Message ("Appending: headers are " + ($script:Header -join ", ") + "Start row $row")
             }
             elseif ($Title) {


### PR DESCRIPTION
Issue only occurs when creating a file using the -Append switch parameter with Export-Excel. The issue was because no rows exist yet, $ws.Dimension.Rows will be null so $row is in turn null.

(First time making a pull request, so please let me know if there's a better way of doing this!)

Edit: I forgot that during testing, you could manually create the file and put data in or make the headers before using append and it would work. But, creating just the empty file beforehand and trying to append into it did not work. 
You'd have to input the headers exactly as they would show in the sheet, and the append would work. Or, you can place data in any cells but the first row and it would work. I'm guessing this is due to when putting any data in, you have created the rows needed for $ws.Dimension.Rows to have a value.