### PR TITLE
Ref: Error when trying to use QueryTimeout #370

### DIFF
--- a/Send-SqlDataToExcel.ps1
+++ b/Send-SqlDataToExcel.ps1
@@ -131,7 +131,7 @@
     $excelPackage.Workbook.Worksheets[$WorkSheetname].Cells[$r,$StartColumn].LoadFromDataTable($dataTable, $printHeaders )  | Out-Null
     
     #Call export-excel with any parameters which don't relate to the SQL query
-    "Connection", "Database" , "Session", "MsSQLserver", "Destination" , "SQL" ,"Path" | ForEach-Object {$null = $PSBoundParameters.Remove($_) }
+    "Connection", "Database" , "Session", "MsSQLserver", "Destination" , "SQL" ,"Path", "QueryTimeout" | ForEach-Object {$null = $PSBoundParameters.Remove($_) }
     Export-Excel -ExcelPackage $excelPackage   @PSBoundParameters 
 
     #If we were not passed a session close the session we created. 


### PR DESCRIPTION
Apparently on the line 134 you're trying to exclude all the SQL related commands but QueryTimeout is still missing so when it tries to execute the excel-import and search for the param QueryTimeout it fails.

Could you please confirm if that failure could be caused by that missing value on that list or is something that should be included as an input?