### PR TITLE
Fix für Issue #397 to convert TextRotation values to working values

### DIFF
--- a/Set-Column.ps1
+++ b/Set-Column.ps1
@@ -123,7 +123,7 @@
     if      ($FontShift)               { $Worksheet.Column(     $Column).Style.Font.VerticalAlign          = $FontShift          }
     if      ($NumberFormat)            { $Worksheet.Column(     $Column).Style.Numberformat.Format         = $NumberFormat       }
 
-    if      ($TextRotation) {
+    if      ($PSBoundParameters.ContainsKey('TextRotation')) {
             if ($TextRotation -lt 0)  {
                                          $Worksheet.Column(     $Column).Style.TextRotation                = 90 - $TextRotation    # Convert -1 to -90 -> 91 to 180  
             } else {

--- a/Set-Column.ps1
+++ b/Set-Column.ps1
@@ -122,7 +122,15 @@
     if      ($StrikeThru)              { $Worksheet.Column(     $Column).Style.Font.Strike                 = $true               }
     if      ($FontShift)               { $Worksheet.Column(     $Column).Style.Font.VerticalAlign          = $FontShift          }
     if      ($NumberFormat)            { $Worksheet.Column(     $Column).Style.Numberformat.Format         = $NumberFormat       }
-    if      ($TextRotation)            { $Worksheet.Column(     $Column).Style.TextRotation                = $TextRotation       }
+
+    if      ($TextRotation) {
+            if ($TextRotation -lt 0)  {
+                                         $Worksheet.Column(     $Column).Style.TextRotation                = 90 - $TextRotation    # Convert -1 to -90 -> 91 to 180  
+            } else {
+                                         $Worksheet.Column(     $Column).Style.TextRotation                = $TextRotation
+            }
+    }
+
     if      ($WrapText)                { $Worksheet.Column(     $Column).Style.WrapText                    = $true               }
     if      ($HorizontalAlignment)     { $Worksheet.Column(     $Column).Style.HorizontalAlignment         = $HorizontalAlignment}
     if      ($VerticalAlignment)       { $Worksheet.Column(     $Column).Style.VerticalAlignment           = $VerticalAlignment  }
@@ -131,7 +139,7 @@
     if      ($BackgroundColor)         {
                                          $Worksheet.Column(     $Column).Style.Fill.PatternType            = $BackgroundPattern
                                          $Worksheet.Column(     $Column).Style.Fill.BackgroundColor.SetColor($BackgroundColor  )
-         if ($PatternColor)            { $Worksheet.Column(     $Column).Style.Fill.PatternColor.SetColor(   $PatternColor     ) }
+        if  ($PatternColor)            { $Worksheet.Column(     $Column).Style.Fill.PatternColor.SetColor(   $PatternColor     ) }
      }
      if     ($Autosize)                { $Worksheet.Column(     $Column).AutoFit()                                               }
      elseif ($Width)                   { $Worksheet.Column(     $Column).Width                             = $Width              }

--- a/Set-Row.ps1
+++ b/Set-Row.ps1
@@ -124,7 +124,7 @@
     if      ($FontShift)                 { $worksheet.row(  $Row  ).Style.Font.VerticalAlign          = $FontShift          }
     if      ($NumberFormat)              { $worksheet.row(  $Row  ).Style.Numberformat.Format         = $NumberFormat       }
 
-    if      ($TextRotation) {
+    if      ($PSBoundParameters.ContainsKey('TextRotation')) {
         if  ($TextRotation -lt 0)  {
                                            $Worksheet.row(  $Row  ).Style.TextRotation                = 90 - $TextRotation    # Convert -1 to -90 -> 91 to 180  
         } else {

--- a/Set-Row.ps1
+++ b/Set-Row.ps1
@@ -123,7 +123,15 @@
     if      ($StrikeThru)                { $worksheet.row(  $Row  ).Style.Font.Strike                 = $true               }
     if      ($FontShift)                 { $worksheet.row(  $Row  ).Style.Font.VerticalAlign          = $FontShift          }
     if      ($NumberFormat)              { $worksheet.row(  $Row  ).Style.Numberformat.Format         = $NumberFormat       }
-    if      ($TextRotation)              { $worksheet.row(  $Row  ).Style.TextRotation                = $TextRotation       }
+
+    if      ($TextRotation) {
+        if  ($TextRotation -lt 0)  {
+                                           $Worksheet.row(  $Row  ).Style.TextRotation                = 90 - $TextRotation    # Convert -1 to -90 -> 91 to 180  
+        } else {
+                                           $Worksheet.row(  $Row  ).Style.TextRotation                = $TextRotation
+        }
+    }
+
     if      ($WrapText)                  { $worksheet.row(  $Row  ).Style.WrapText                    = $true               }
     if      ($HorizontalAlignment)       { $worksheet.row(  $Row  ).Style.HorizontalAlignment         = $HorizontalAlignment}
     if      ($VerticalAlignment)         { $worksheet.row(  $Row  ).Style.VerticalAlignment           = $VerticalAlignment  }

--- a/SetFormat.ps1
+++ b/SetFormat.ps1
@@ -117,6 +117,7 @@
                 }
             }
             
+            if ($WrapText)            {$Address.Style.WrapText            = $true                }
             if ($HorizontalAlignment) {$Address.Style.HorizontalAlignment = $HorizontalAlignment }
             if ($VerticalAlignment)   {$Address.Style.VerticalAlignment   = $VerticalAlignment   }
             if ($Value)               {$Address.Value = $Value                                   }

--- a/SetFormat.ps1
+++ b/SetFormat.ps1
@@ -108,8 +108,15 @@
             if ($FontShift)           {$Address.Style.Font.VerticalAlign  = $FontShift           }
             if ($FontColor)           {$Address.Style.Font.Color.SetColor(  $FontColor    )      }
             if ($NumberFormat)        {$Address.Style.Numberformat.Format = $NumberFormat        }
-            if ($TextRotation)        {$Address.Style.TextRotation        = $TextRotation        }
-            if ($WrapText)            {$Address.Style.WrapText            = $true                }
+
+            if ($TextRotation) {
+                if ($TextRotation -lt 0) {
+                                       $Address.Style.TextRotation        = 90 - $TextRotation     # Convert -1 to -90 -> 91 to 180 
+                } else {
+                                       $Address.Style.TextRotation        = $TextRotation
+                }
+            }
+            
             if ($HorizontalAlignment) {$Address.Style.HorizontalAlignment = $HorizontalAlignment }
             if ($VerticalAlignment)   {$Address.Style.VerticalAlignment   = $VerticalAlignment   }
             if ($Value)               {$Address.Value = $Value                                   }

--- a/SetFormat.ps1
+++ b/SetFormat.ps1
@@ -109,7 +109,7 @@
             if ($FontColor)           {$Address.Style.Font.Color.SetColor(  $FontColor    )      }
             if ($NumberFormat)        {$Address.Style.Numberformat.Format = $NumberFormat        }
 
-            if ($TextRotation) {
+            if ($PSBoundParameters.ContainsKey('TextRotation')) {
                 if ($TextRotation -lt 0) {
                                        $Address.Style.TextRotation        = 90 - $TextRotation     # Convert -1 to -90 -> 91 to 180 
                 } else {

--- a/formatting.ps1
+++ b/formatting.ps1
@@ -173,7 +173,7 @@ Function Set-Format {
         if ($BorderAround)        {$Range.Style.Border.BorderAround( $BorderAround )      }
         if ($NumberFormat)        {$Range.Style.Numberformat.Format= $NumberFormat        }
 
-        if ($TextRotation) {
+        if ($PSBoundParameters.ContainsKey('TextRotation')) {
             if ($TextRotation -lt 0) {
                                    $Range.Style.TextRotation       = 90 - $TextRotation     # Convert -1 to -90 -> 91 to 180 
             } else {

--- a/formatting.ps1
+++ b/formatting.ps1
@@ -181,7 +181,7 @@ Function Set-Format {
             }
         }
         
-    if ($WrapText)            {$Range.Style.WrapText           = $true                }
+        if ($WrapText)            {$Range.Style.WrapText           = $true                }
         if ($HorizontalAlignment) {$Range.Style.HorizontalAlignment= $HorizontalAlignment }
         if ($VerticalAlignment)   {$Range.Style.VerticalAlignment  = $VerticalAlignment   }
 

--- a/formatting.ps1
+++ b/formatting.ps1
@@ -170,10 +170,18 @@ Function Set-Format {
         if ($StrikeThru)          {$Range.Style.Font.Strike        = $true                }
         if ($FontShift)           {$Range.Style.Font.VerticalAlign = $FontShift           }
         if ($FontColor)           {$Range.Style.Font.Color.SetColor( $FontColor    )      }
-        if ($BorderAround)         {$Range.Style.Border.BorderAround( $BorderAround )      }
+        if ($BorderAround)        {$Range.Style.Border.BorderAround( $BorderAround )      }
         if ($NumberFormat)        {$Range.Style.Numberformat.Format= $NumberFormat        }
-        if ($TextRotation)        {$Range.Style.TextRotation       = $TextRotation        }
-        if ($WrapText)            {$Range.Style.WrapText           = $true                }
+
+        if ($TextRotation) {
+            if ($TextRotation -lt 0) {
+                                   $Range.Style.TextRotation       = 90 - $TextRotation     # Convert -1 to -90 -> 91 to 180 
+            } else {
+                                   $Range.Style.TextRotation       = $TextRotation
+            }
+        }
+        
+    if ($WrapText)            {$Range.Style.WrapText           = $true                }
         if ($HorizontalAlignment) {$Range.Style.HorizontalAlignment= $HorizontalAlignment }
         if ($VerticalAlignment)   {$Range.Style.VerticalAlignment  = $VerticalAlignment   }
 


### PR DESCRIPTION
The TextRotation parameter is described and tested for values from -90 to 90. But the values accepted (by the DLL ?) are 0 to 180. This works like this:

 0°   to   90°  =   Values 0 to 90
-1°   to  -90°  =   Values 91 to 180

I added a test to convert negative input values. While testing this I found that it was impossible to reset the text rotation to 0°. This is due the to simple test if a parameter is set by only do like
`if ($TextRotation){........}`

I changed this to 
`if ($PSBoundParameters.ContainsKey('TextRotation')) {.......}`
So if you specify now the option "-TextRotation 0" it resets the rotation to 0.
