### PR TITLE
fix for loading on case-sensitive filesystems

### DIFF
--- a/ImportExcel.psm1
+++ b/ImportExcel.psm1
@@ -4,7 +4,7 @@
     . $PSScriptRoot\Charting.ps1
     . $PSScriptRoot\ColorCompletion.ps1
     . $PSScriptRoot\ConvertExcelToImageFile.ps1
-    . $PSScriptRoot\Compare-WorkSheet.ps1
+    . $PSScriptRoot\compare-worksheet.ps1
     . $PSScriptRoot\ConvertFromExcelData.ps1
     . $PSScriptRoot\ConvertFromExcelToSQLInsert.ps1
     . $PSScriptRoot\ConvertToExcelXlsx.ps1
@@ -20,8 +20,8 @@
     . $PSScriptRoot\Import-Html.ps1
     . $PSScriptRoot\InferData.ps1
     . $PSScriptRoot\Invoke-Sum.ps1
-    . $PSScriptRoot\Join-WorkSheet.ps1
-    . $PSScriptRoot\Merge-Worksheet.ps1
+    . $PSScriptRoot\Join-Worksheet.ps1
+    . $PSScriptRoot\Merge-worksheet.ps1
     . $PSScriptRoot\New-ConditionalFormattingIconSet.ps1
     . $PSScriptRoot\New-ConditionalText.ps1
     . $PSScriptRoot\New-ExcelChart.ps1
@@ -29,7 +29,7 @@
     . $PSScriptRoot\Open-ExcelPackage.ps1
     . $PSScriptRoot\Pivot.ps1
     . $PSScriptRoot\PivotTable.ps1
-    . $PSScriptRoot\Send-SQLDataToExcel.ps1
+    . $PSScriptRoot\Send-SqlDataToExcel.ps1
     . $PSScriptRoot\Set-CellStyle.ps1
     . $PSScriptRoot\Set-Column.ps1
     . $PSScriptRoot\Set-Row.ps1
@@ -41,7 +41,7 @@
     New-Alias -Name Use-ExcelData -Value "ConvertFrom-ExcelData" -Force
 
     if ($PSVersionTable.PSVersion.Major -ge 5) {
-        . $PSScriptRoot\Plot.ps1
+        . $PSScriptRoot\plot.ps1
 
         Function New-Plot {
             Param()


### PR DESCRIPTION
On linux/docker, powershell can't load some of the modules.

Here is an example of the error message:

    . : The module '/usr/local/share/powershell/Modules/ImportExcel/5.3.4'
    could not be loaded. For more information, run 'Import-Module
    /usr/local/share/powershell/Modules/ImportExcel/5.3.4'.
    At
    /usr/local/share/powershell/Modules/ImportExcel/5.3.4/ImportExcel.psm1:7
    char:7
    +     . $PSScriptRoot\Compare-WorkSheet.ps1
    +       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound:
    (/usr/local/shar...e-WorkSheet.ps1:String) [], CommandNotFoundException
    + FullyQualifiedErrorId : CouldNotAutoLoadModule

The reason for this is that the filenames on disk have different
capitalization than the filenames in ImportExcel.psm1.