### PR TITLE
Chart supports multiple X ranges and headers from cells

### DIFF
--- a/New-ExcelChart.ps1
+++ b/New-ExcelChart.ps1
@@ -219,7 +219,7 @@ function Add-ExcelChart {
       .PARAMETER NoLegend
         If specified, turns of display of the key. If you only have one data series it may be preferable to use the title to say what the chart is.
       .PARAMETER SeriesHeader
-        Specify explicit name(s) for the data series, which will appear in the legend/key
+        Specify explicit name(s) for the data series, which will appear in the legend/key. The contents of a cell can be specified in the from =Sheet9!Z10 .
        .PARAMETER LegendPosition
         Location of the key, either left, right, top, bottom or TopRight.
       .PARAMETER LegendSize
@@ -349,7 +349,7 @@ function Add-ExcelChart {
         [Switch]$NoLegend,
         [Switch]$ShowCategory,
         [Switch]$ShowPercent,
-        $SeriesHeader,
+        [String[]]$SeriesHeader,
         [Switch]$TitleBold,
         [Int]$TitleSize ,
         [String]$XAxisTitleText,
@@ -388,8 +388,16 @@ function Add-ExcelChart {
             }
             else {
                 for ($idx = 0; $idx -lt $chartDefCount; $idx += 1) {
-                    $Series = $chart.Series.Add($YRange[$idx], $XRange)
-                    if ($SeriesHeader.Count -gt 0) { $Series.Header = $SeriesHeader[$idx] }
+                    if ($Yrange.count -eq $xrange.count) {
+                      $Series = $chart.Series.Add($YRange[$idx], $XRange[$idx])
+                    }
+                    else {
+                      $Series = $chart.Series.Add($YRange[$idx], $XRange)
+                    }
+                    if ($SeriesHeader.Count -gt 0) {
+                      if ($SeriesHeader[$idx] -match '^=') {$Series.HeaderAddress = $SeriesHeader[$idx] -replace '^=',''}
+                      else                                 {$Series.Header        = $SeriesHeader[$idx] }
+                    }
                     else { $Series.Header = "Series $($idx)"}
                 }
             }

--- a/README.md
+++ b/README.md
@@ -57,9 +57,11 @@ Install-Module ImportExcel
 
 - Thank you to Conrad Agramont, Twitter: [@AGramont](https://twitter.com/@AGramont) for the `AddMultiWorkSheet.ps1` example. Much appreciated!
 - Fixed several more bugs where parametrs were ignored if passed a zero value 
+- Fixed bug where chart series headers could not come form a cell refernce (=Sheet1!Z10 now works as a header reference)
+- Add-Chart will now allow a single X range, or as many X ranges as there are Y ranges.
 - Merge-MultipleSheets is more robust. 
 - Set-ExcelRow and Set-ExcelColumn trap attempts to process a sheet with no rows/columns.
-- Help has been proof-read . 
+- Help has been proof-read (thanks to Mrs @Jhoneill !). 
 
 # What's new 5.3.4
 


### PR DESCRIPTION
Two small tweaks to Add-Chart
(a) A series header was always set as literal string. Now if it begins with = what follows the = sign is set as the header address (so labels can come from cells)
(b) in #420 and #486 there is discussion of adding some code so if there were many X ranges each Y range got its own X range. This never got added to the code I checked in, but it's in now. 

