### PR TITLE
fixed lastColumn issues when more than 10 rows exist in excel sheet

### DIFF
--- a/Export-Excel.ps1
+++ b/Export-Excel.ps1
@@ -1036,7 +1036,7 @@
         if ($CellStyleSB) {
             try {
                 $TotalRows = $ws.Dimension.Rows
-                $LastColumn = $ws.Dimension.Address -replace "^.*:(\w*)\d+$" , '$1'
+                $LastColumn = $ws.Dimension.Address -replace "^.*:([a-zA-Z]*)\d+$" , '$1'
                 & $CellStyleSB $ws $TotalRows $LastColumn
             }
             catch {Write-Warning -Message "Failed processing CellStyleSB in worksheet '$WorksheetName': $_"}


### PR DESCRIPTION
I had an issue where the dimension value would be
E17
So the old regex would output E1 as last column, which made the other commands fail.

Updating the regex to only accept letters as 0-9 is part of \w