### PR TITLE
Correct type casting syntax (fixes #551).

### DIFF
--- a/AddConditionalFormatting.ps1
+++ b/AddConditionalFormatting.ps1
@@ -193,7 +193,7 @@
     if (-not $worksheet -or $WorkSheet -isnot [OfficeOpenXml.ExcelWorksheet]) {write-warning "You need to provide a worksheet object." ; return}
     #region create a rule of the right type
     if     ($RuleType -match 'IconSet$') {Write-warning -Message "You cannot configure a Icon-Set rule in this way; please use -$RuleType <SetName>." ; return}
-    if ($PSBoundParameters.ContainsKey("DataBarColor"  )      ) {if ($DataBarColor -is [string]) {$DataBarColor = [System.Drawing.Color]::$DataBarColor }
+    if ($PSBoundParameters.ContainsKey("DataBarColor"  )      ) {if ($DataBarColor -is [string]) {$DataBarColor = [System.Drawing.Color] $DataBarColor }
                                                                      $rule =  $WorkSheet.ConditionalFormatting.AddDatabar(     $Address , $DataBarColor )
     }
     elseif ($PSBoundParameters.ContainsKey("ThreeIconsSet" )      ) {$rule =  $WorkSheet.ConditionalFormatting.AddThreeIconSet($Address , $ThreeIconsSet)}
@@ -257,12 +257,12 @@
     if     ($PSBoundParameters.ContainsKey("Bold"             )   ) {$rule.Style.Font.Bold                  = [boolean]$Bold       }
     if     ($PSBoundParameters.ContainsKey("Italic"           )   ) {$rule.Style.Font.Italic                = [boolean]$Italic     }
     if     ($PSBoundParameters.ContainsKey("StrikeThru"       )   ) {$rule.Style.Font.Strike                = [boolean]$StrikeThru }
-    if     ($PSBoundParameters.ContainsKey("ForeGroundColor"  )   ) {if ($ForeGroundColor -is [string])      {$ForeGroundColor = [System.Drawing.Color]::$ForeGroundColor }
+    if     ($PSBoundParameters.ContainsKey("ForeGroundColor"  )   ) {if ($ForeGroundColor -is [string])      {$ForeGroundColor = [System.Drawing.Color] $ForeGroundColor }
                                                                      $rule.Style.Font.Color.color           = $ForeGroundColor     }
-    if     ($PSBoundParameters.ContainsKey("BackgroundColor"  )   ) {if ($BackgroundColor -is [string])      {$BackgroundColor = [System.Drawing.Color]::$BackgroundColor }
+    if     ($PSBoundParameters.ContainsKey("BackgroundColor"  )   ) {if ($BackgroundColor -is [string])      {$BackgroundColor = [System.Drawing.Color] $BackgroundColor }
                                                                      $rule.Style.Fill.BackgroundColor.color = $BackgroundColor     }
     if     ($PSBoundParameters.ContainsKey("BackgroundPattern")   ) {$rule.Style.Fill.PatternType           = $BackgroundPattern   }
-    if     ($PSBoundParameters.ContainsKey("PatternColor"     )   ) {if ($PatternColor -is [string])         {$PatternColor = [System.Drawing.Color]::$PatternColor }
+    if     ($PSBoundParameters.ContainsKey("PatternColor"     )   ) {if ($PatternColor -is [string])         {$PatternColor = [System.Drawing.Color] $PatternColor }
                                                                      $rule.Style.Fill.PatternColor.color    = $PatternColor        }
     #endregion
     #Allow further tweaking by returning the rule, if passthru specified

--- a/AddConditionalFormatting.ps1
+++ b/AddConditionalFormatting.ps1
@@ -193,7 +193,7 @@
     if (-not $worksheet -or $WorkSheet -isnot [OfficeOpenXml.ExcelWorksheet]) {write-warning "You need to provide a worksheet object." ; return}
     #region create a rule of the right type
     if     ($RuleType -match 'IconSet$') {Write-warning -Message "You cannot configure a Icon-Set rule in this way; please use -$RuleType <SetName>." ; return}
-    if ($PSBoundParameters.ContainsKey("DataBarColor"  )      ) {if ($DataBarColor -is [string]) {$DataBarColor = [System.Drawing.Color] $DataBarColor }
+    if ($PSBoundParameters.ContainsKey("DataBarColor"  )      ) {if ($DataBarColor -is [string]) {$DataBarColor = [System.Drawing.ColorTranslator]::FromHtml($DataBarColor) }
                                                                      $rule =  $WorkSheet.ConditionalFormatting.AddDatabar(     $Address , $DataBarColor )
     }
     elseif ($PSBoundParameters.ContainsKey("ThreeIconsSet" )      ) {$rule =  $WorkSheet.ConditionalFormatting.AddThreeIconSet($Address , $ThreeIconsSet)}
@@ -257,12 +257,12 @@
     if     ($PSBoundParameters.ContainsKey("Bold"             )   ) {$rule.Style.Font.Bold                  = [boolean]$Bold       }
     if     ($PSBoundParameters.ContainsKey("Italic"           )   ) {$rule.Style.Font.Italic                = [boolean]$Italic     }
     if     ($PSBoundParameters.ContainsKey("StrikeThru"       )   ) {$rule.Style.Font.Strike                = [boolean]$StrikeThru }
-    if     ($PSBoundParameters.ContainsKey("ForeGroundColor"  )   ) {if ($ForeGroundColor -is [string])      {$ForeGroundColor = [System.Drawing.Color] $ForeGroundColor }
+    if     ($PSBoundParameters.ContainsKey("ForeGroundColor"  )   ) {if ($ForeGroundColor -is [string])      {$ForeGroundColor = [System.Drawing.ColorTranslator]::FromHtml($ForeGroundColor) }
                                                                      $rule.Style.Font.Color.color           = $ForeGroundColor     }
-    if     ($PSBoundParameters.ContainsKey("BackgroundColor"  )   ) {if ($BackgroundColor -is [string])      {$BackgroundColor = [System.Drawing.Color] $BackgroundColor }
+    if     ($PSBoundParameters.ContainsKey("BackgroundColor"  )   ) {if ($BackgroundColor -is [string])      {$BackgroundColor = [System.Drawing.ColorTranslator]::FromHtml($BackgroundColor) }
                                                                      $rule.Style.Fill.BackgroundColor.color = $BackgroundColor     }
     if     ($PSBoundParameters.ContainsKey("BackgroundPattern")   ) {$rule.Style.Fill.PatternType           = $BackgroundPattern   }
-    if     ($PSBoundParameters.ContainsKey("PatternColor"     )   ) {if ($PatternColor -is [string])         {$PatternColor = [System.Drawing.Color] $PatternColor }
+    if     ($PSBoundParameters.ContainsKey("PatternColor"     )   ) {if ($PatternColor -is [string])         {$PatternColor = [System.Drawing.ColorTranslator]::FromHtml($PatternColor) }
                                                                      $rule.Style.Fill.PatternColor.color    = $PatternColor        }
     #endregion
     #Allow further tweaking by returning the rule, if passthru specified

--- a/Export-Excel.ps1
+++ b/Export-Excel.ps1
@@ -688,7 +688,7 @@
                     $ws.Cells[$Row, $StartColumn].Style.Font.Bold = [boolean]$TitleBold
                 }
                 if ($TitleBackgroundColor ) {
-                    if ($TitleBackgroundColor -is [string])         {$TitleBackgroundColor = [System.Drawing.Color]::$TitleBackgroundColor }
+                    if ($TitleBackgroundColor -is [string])         {$TitleBackgroundColor = [System.Drawing.Color] $TitleBackgroundColor }
                     $ws.Cells[$Row, $StartColumn].Style.Fill.PatternType = $TitleFillPattern
                     $ws.Cells[$Row, $StartColumn].Style.Fill.BackgroundColor.SetColor($TitleBackgroundColor)
                 }

--- a/Export-Excel.ps1
+++ b/Export-Excel.ps1
@@ -688,7 +688,7 @@
                     $ws.Cells[$Row, $StartColumn].Style.Font.Bold = [boolean]$TitleBold
                 }
                 if ($TitleBackgroundColor ) {
-                    if ($TitleBackgroundColor -is [string])         {$TitleBackgroundColor = [System.Drawing.Color] $TitleBackgroundColor }
+                    if ($TitleBackgroundColor -is [string])         {$TitleBackgroundColor = [System.Drawing.ColorTranslator]::FromHtml($TitleBackgroundColor) }
                     $ws.Cells[$Row, $StartColumn].Style.Fill.PatternType = $TitleFillPattern
                     $ws.Cells[$Row, $StartColumn].Style.Fill.BackgroundColor.SetColor($TitleBackgroundColor)
                 }

--- a/Join-Worksheet.ps1
+++ b/Join-Worksheet.ps1
@@ -149,7 +149,7 @@
         if ($TitleBold) {$destinationSheet.Cells[1, 1].Style.Font.Bold = $True }
         #Can only set TitleBackgroundColor if TitleFillPattern is something other than None.
         if ($TitleBackgroundColor -AND ($TitleFillPattern -ne 'None')) {
-            if ($TitleBackgroundColor -is [string])         {$TitleBackgroundColor = [System.Drawing.Color]::$TitleBackgroundColor }
+            if ($TitleBackgroundColor -is [string])         {$TitleBackgroundColor = [System.Drawing.Color] $TitleBackgroundColor }
             $destinationSheet.Cells[1, 1].Style.Fill.PatternType = $TitleFillPattern
             $destinationSheet.Cells[1, 1].Style.Fill.BackgroundColor.SetColor($TitleBackgroundColor)
         }

--- a/Join-Worksheet.ps1
+++ b/Join-Worksheet.ps1
@@ -149,7 +149,7 @@
         if ($TitleBold) {$destinationSheet.Cells[1, 1].Style.Font.Bold = $True }
         #Can only set TitleBackgroundColor if TitleFillPattern is something other than None.
         if ($TitleBackgroundColor -AND ($TitleFillPattern -ne 'None')) {
-            if ($TitleBackgroundColor -is [string])         {$TitleBackgroundColor = [System.Drawing.Color] $TitleBackgroundColor }
+            if ($TitleBackgroundColor -is [string])         {$TitleBackgroundColor = [System.Drawing.ColorTranslator]::FromHtml($TitleBackgroundColor) }
             $destinationSheet.Cells[1, 1].Style.Fill.PatternType = $TitleFillPattern
             $destinationSheet.Cells[1, 1].Style.Fill.BackgroundColor.SetColor($TitleBackgroundColor)
         }

--- a/Set-CellStyle.ps1
+++ b/Set-CellStyle.ps1
@@ -6,7 +6,7 @@
         [OfficeOpenXml.Style.ExcelFillStyle]$Pattern,
         $Color
     )
-    if ($Color -is [string])         {$Color = [System.Drawing.Color] $Color }
+    if ($Color -is [string])         {$Color = [System.Drawing.ColorTranslator]::FromHtml($Color) }
     $t=$WorkSheet.Cells["A$($Row):$($LastColumn)$($Row)"]
     $t.Style.Fill.PatternType=$Pattern
     $t.Style.Fill.BackgroundColor.SetColor($Color)

--- a/Set-CellStyle.ps1
+++ b/Set-CellStyle.ps1
@@ -6,7 +6,7 @@
         [OfficeOpenXml.Style.ExcelFillStyle]$Pattern,
         $Color
     )
-    if ($Color -is [string])         {$Color = [System.Drawing.Color]::$Color }
+    if ($Color -is [string])         {$Color = [System.Drawing.Color] $Color }
     $t=$WorkSheet.Cells["A$($Row):$($LastColumn)$($Row)"]
     $t.Style.Fill.PatternType=$Pattern
     $t.Style.Fill.BackgroundColor.SetColor($Color)

--- a/SetFormat.ps1
+++ b/SetFormat.ps1
@@ -150,7 +150,7 @@
                 $Range.Style.Font.VerticalAlign  = $FontShift
             }
             if ($PSBoundParameters.ContainsKey('FontColor')){
-                if ($FontColor -is [string]) {$FontColor = [System.Drawing.Color] $FontColor }
+                if ($FontColor -is [string]) {$FontColor = [System.Drawing.ColorTranslator]::FromHtml($FontColor) }
                 $Range.Style.Font.Color.SetColor(  $FontColor)
             }
             if ($PSBoundParameters.ContainsKey('TextRotation')) {
@@ -180,7 +180,7 @@
             if ($PSBoundParameters.ContainsKey('NumberFormat')) {
                 $Range.Style.Numberformat.Format = (Expand-NumberFormat $NumberFormat)
             }
-            if ($BorderColor -is [string]) {$BorderColor = [System.Drawing.Color] $BorderColor }
+            if ($BorderColor -is [string]) {$BorderColor = [System.Drawing.ColorTranslator]::FromHtml($BorderColor) }
             if ($PSBoundParameters.ContainsKey('BorderAround')) {
                 $Range.Style.Border.BorderAround($BorderAround, $BorderColor)
             }
@@ -202,10 +202,10 @@
             }
             if ($PSBoundParameters.ContainsKey('BackgroundColor')) {
                 $Range.Style.Fill.PatternType = $BackgroundPattern
-                if ($BackgroundColor -is [string]) {$BackgroundColor = [System.Drawing.Color] $BackgroundColor }
+                if ($BackgroundColor -is [string]) {$BackgroundColor = [System.Drawing.ColorTranslator]::FromHtml($BackgroundColor) }
                 $Range.Style.Fill.BackgroundColor.SetColor($BackgroundColor)
                 if ($PatternColor) {
-                    if ($PatternColor -is [string]) {$PatternColor = [System.Drawing.Color] $PatternColor }
+                    if ($PatternColor -is [string]) {$PatternColor = [System.Drawing.ColorTranslator]::FromHtml($PatternColor) }
                     $Range.Style.Fill.PatternColor.SetColor( $PatternColor)
                 }
             }

--- a/SetFormat.ps1
+++ b/SetFormat.ps1
@@ -150,7 +150,7 @@
                 $Range.Style.Font.VerticalAlign  = $FontShift
             }
             if ($PSBoundParameters.ContainsKey('FontColor')){
-                if ($FontColor -is [string]) {$FontColor = [System.Drawing.Color]::$FontColor }
+                if ($FontColor -is [string]) {$FontColor = [System.Drawing.Color] $FontColor }
                 $Range.Style.Font.Color.SetColor(  $FontColor)
             }
             if ($PSBoundParameters.ContainsKey('TextRotation')) {
@@ -180,7 +180,7 @@
             if ($PSBoundParameters.ContainsKey('NumberFormat')) {
                 $Range.Style.Numberformat.Format = (Expand-NumberFormat $NumberFormat)
             }
-            if ($BorderColor -is [string]) {$BorderColor = [System.Drawing.Color]::$BorderColor }
+            if ($BorderColor -is [string]) {$BorderColor = [System.Drawing.Color] $BorderColor }
             if ($PSBoundParameters.ContainsKey('BorderAround')) {
                 $Range.Style.Border.BorderAround($BorderAround, $BorderColor)
             }
@@ -202,10 +202,10 @@
             }
             if ($PSBoundParameters.ContainsKey('BackgroundColor')) {
                 $Range.Style.Fill.PatternType = $BackgroundPattern
-                if ($BackgroundColor -is [string]) {$BackgroundColor = [System.Drawing.Color]::$BackgroundColor }
+                if ($BackgroundColor -is [string]) {$BackgroundColor = [System.Drawing.Color] $BackgroundColor }
                 $Range.Style.Fill.BackgroundColor.SetColor($BackgroundColor)
                 if ($PatternColor) {
-                    if ($PatternColor -is [string]) {$PatternColor = [System.Drawing.Color]::$PatternColor }
+                    if ($PatternColor -is [string]) {$PatternColor = [System.Drawing.Color] $PatternColor }
                     $Range.Style.Fill.PatternColor.SetColor( $PatternColor)
                 }
             }

--- a/compare-worksheet.ps1
+++ b/compare-worksheet.ps1
@@ -182,7 +182,7 @@
                 Set-Format -WorkSheet $ws -Range $range -BackgroundColor $BackgroundColor
             }
             if  ($PSBoundParameters.ContainsKey("TabColor")) {
-                if ($TabColor -is [string])         {$TabColor = [System.Drawing.Color]::$TabColor }
+                if ($TabColor -is [string])         {$TabColor = [System.Drawing.Color] $TabColor }
                 foreach ($tab in ($file.group._sheet | Select-Object -Unique)) {
                     $xl.Workbook.Worksheets[$tab].TabColor = $TabColor
                  }

--- a/compare-worksheet.ps1
+++ b/compare-worksheet.ps1
@@ -182,7 +182,7 @@
                 Set-Format -WorkSheet $ws -Range $range -BackgroundColor $BackgroundColor
             }
             if  ($PSBoundParameters.ContainsKey("TabColor")) {
-                if ($TabColor -is [string])         {$TabColor = [System.Drawing.Color] $TabColor }
+                if ($TabColor -is [string])         {$TabColor = [System.Drawing.ColorTranslator]::FromHtml($TabColor) }
                 foreach ($tab in ($file.group._sheet | Select-Object -Unique)) {
                     $xl.Workbook.Worksheets[$tab].TabColor = $TabColor
                  }


### PR DESCRIPTION
Type casting had a syntax error such that some lines referred to a static member instead of the parameter being cast. Fixes #551. 