### PR TITLE
Perf improvements for Export-Excel

### DIFF
--- a/Export-Excel.ps1
+++ b/Export-Excel.ps1
@@ -423,7 +423,7 @@
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingPlainTextForPassword", "")]
     Param(
         [Parameter(ParameterSetName = "Default", Position = 0)]
-        [Parameter(ParameterSetName = "Table"  , Position = 0)]
+        [Parameter(Mandatory = $true, ParameterSetName = "Table"  , Position = 0)]
         [String]$Path,
         [Parameter(Mandatory = $true, ParameterSetName = "PackageDefault")]
         [Parameter(Mandatory = $true, ParameterSetName = "PackageTable")]
@@ -747,11 +747,12 @@
                     catch {Write-Warning -Message "Could not insert the '$Name' property at Row $Row, Column $ColumnIndex"}
                     $ColumnIndex += 1
                 }
+                $ColumnIndex -= 1 # column index will be the last column whether isDataTypeValueType was true or false
                 #endregion
             }
         }
         catch {throw "Failed exporting data to worksheet '$WorksheetName' to '$Path': $_" }
-        $ColumnIndex -= 1 # column index will be the last column whether isDataTypeValueType was true or false
+
     }}
 
     end {

--- a/Export-Excel.ps1
+++ b/Export-Excel.ps1
@@ -423,7 +423,7 @@
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingPlainTextForPassword", "")]
     Param(
         [Parameter(ParameterSetName = "Default", Position = 0)]
-        [Parameter(Mandatory = $true, ParameterSetName = "Table"  , Position = 0)]
+        [Parameter(ParameterSetName = "Table"  , Position = 0)]
         [String]$Path,
         [Parameter(Mandatory = $true, ParameterSetName = "PackageDefault")]
         [Parameter(Mandatory = $true, ParameterSetName = "PackageTable")]

--- a/ImportExcel.psd1
+++ b/ImportExcel.psd1
@@ -61,16 +61,83 @@ Check out the How To Videos https://www.youtube.com/watch?v=U3Ne_yX4tYo&list=PL5
     # NestedModules = @()
 
     # Functions to export from this module
-    FunctionsToExport = '*'
+    FunctionsToExport = @(
+        'BarChart',
+        'ColumnChart',
+        'DoChart',
+        'LineChart',
+        'PieChart',
+        'Pivot',
+        'Get-XYRange',
+        'Invoke-AllTests',
+        'Test-Boolean',
+        'Test-Date',
+        'Test-Integer',
+        'Test-Number',
+        'Test-String',
+        'New-PSItem',
+        'Import-Html',
+        'Import-UPS',
+        'Import-USPS',
+        'Add-ConditionalFormatting',
+        'Add-ExcelChart',
+        'Add-ExcelDataValidationRule',
+        'Add-ExcelName',
+        'Add-ExcelTable',
+        'Add-PivotTable',
+        'Add-WorkSheet',
+        'Close-ExcelPackage',
+        'Compare-WorkSheet',
+        'ConvertFrom-ExcelData',
+        'ConvertFrom-ExcelSheet',
+        'ConvertFrom-ExcelToSQLInsert',
+        'ConvertTo-ExcelXlsx',
+        'Convert-XlRangeToImage',
+        'Copy-ExcelWorkSheet',
+        'Expand-NumberFormat',
+        'Export-Excel',
+        'Export-ExcelSheet',
+        'Export-MultipleExcelSheets',
+        'Get-ExcelColumnName',
+        'Get-ExcelSheetInfo',
+        'Get-ExcelWorkbookInfo',
+        'Get-HtmlTable',
+        'Get-Range',
+        'Import-Excel',
+        'Invoke-Sum',
+        'Join-Worksheet',
+        'Merge-MultipleSheets',
+        'Merge-Worksheet',
+        'New-ConditionalFormattingIconSet',
+        'New-ConditionalText',
+        'New-ExcelChartDefinition',
+        'New-PivotTableDefinition',
+        'New-Plot',
+        'NumberFormatCompletion',
+        'Open-ExcelPackage',
+        'Remove-WorkSheet'
+        'Select-Worksheet',
+        'Send-SQLDataToExcel',
+        'Set-CellStyle',
+        'Set-ExcelColumn',
+        'Set-ExcelRange',
+        'Set-ExcelRow',
+        'Update-FirstObjectProperties'
+    )
 
     # Cmdlets to export from this module
-    CmdletsToExport   = '*'
+    #CmdletsToExport   = '*'
 
     # Variables to export from this module
-    VariablesToExport = '*'
+    #VariablesToExport = '*'
 
     # Aliases to export from this module
-    AliasesToExport   = '*'
+    AliasesToExport   = @('New-ExcelChart',
+                          'Set-Column',
+                          'Set-Format',
+                          'Set-Row',
+                          'Use-ExcelData'
+    )
 
     # List of all modules packaged with this module
     # ModuleList = @()

--- a/README.md
+++ b/README.md
@@ -52,14 +52,28 @@ Install-Module ImportExcel -scope CurrentUser
 ```PowerShell
 Install-Module ImportExcel
 ```
-# What's new
+# What's new this time. 
+- Performance improvement to Export-Excel see #506 and #555. This has meant taking code in Add-CellValue back into process the body of Export-Excel, as the overhead of calling the function was greater than time executing the code inside it. [Blog post to follow](https://jamesone111.wordpress.com). Some tests are showing a ~10x speed increase. #572 was about a broken #region tag in this part of the code and that has been cleaned up in the process. 
+- Export-Excel now has an `-InputObject` parameter (this was previously `-TargetData` , which is now an alias for InputObject).
+ If the `inputobject` is an array, each item will be inserted, so you can run `export-excel -inputobject $x` rather than `$x | Export-Excel`, and if it is a `system.data.datatable` object it will be inserted directly rather than cell-by-cell. Send-SQLDataToExcel takes advantage of this new functionality. 
+- Export-Excel previously assumed `-Now` if there were no other parameters, it will now assume `-Now` if there is no `-Path` or `-ExcelPackage`.     
+- The .PSD1 file now itemizes the items exported by the module (#557) 
+
+# What's new 5.4.5
+
+Thank you to [James O'Neill](https://github.com/jhoneill) for the great additions.
+
 - Modified Send-SQLDataToExcel so it creates tables and ranges itself; previously it relied on export-excel to do this which cause problems when adding data to an existing sheet (#555)
 - Added new command Add-ExcelDataValidation which will apply different data-validation rules to ranges of cells
-- Changed the export behavior so that (1) attempts to convert to a number only apply if the the value was a string; (2) Nulls are no longer converted to an empty string (3) there is a specific check for URIs and not just text which is a valid URI. Using UNC names in hyperlinks remains problematic.   
-- Changed the behavior of AutoSize in export excel so it only applies to the exported columns. Previously if something was exported next to pre-existing data, AutoSize would resize the whole sheet, potentially undoing things which had been set on the earlier data. If anyone relied on this behavior they will need to explictly tell the sheet to auto size with $sheet.cells.autofitColumns. (where $sheet points to the sheet, it might be $ExcelPackage.Workbook.Worksheets['Name'])
-- In Compare-Worksheet,the Key for comparing the sheets can now be written as a hash table with an expression - it is used with a Group-Object command so if it is valid in Group-Object it should be accepted; this allows the creation of composite keys when data being compared doesn't have a column which uniquely identifies rows. 
--  In Set-ExcelRange , added a 'Locked' option eqivalent to the checkbox on the Protection Tab of the format cells dialog box in Excel.
-- Created a Set-WorksheetProtection function. This gives the same options the protection dialog in Excel but is 0.9 release at the moment. 
+- Changed the export behavior so that (1) attempts to convert to a number only apply if the the value was a string; (2) Nulls are no longer converted to an empty string (3) there is a specific check for URIs and not just text which is a valid URI. Using UNC names in hyperlinks remains problematic.
+- Changed the behavior of AutoSize in export excel so it only applies to the exported columns. Previously if something was exported next to pre-existing data, AutoSize would resize the whole sheet, potentially undoing things which had been set on the earlier data. If anyone relied on this behavior they will need to explicitly tell the sheet to auto size with $sheet.cells.autofitColumns. (where $sheet points to the sheet, it might be $ExcelPackage.Workbook.Worksheets['Name'])
+- In Compare-Worksheet,the Key for comparing the sheets can now be written as a hash table with an expression - it is used with a Group-Object command so if it is valid in Group-Object it should be accepted; this allows the creation of composite keys when data being compared doesn't have a column which uniquely identifies rows.
+-  In Set-ExcelRange , added a 'Locked' option equivalent to the checkbox on the Protection Tab of the format cells dialog box in Excel.
+- Created a Set-WorksheetProtection function. This gives the same options the protection dialog in Excel but is 0.9 release at the moment.
+
+## New Example
+
+- Added [MutipleValidations.ps1](https://github.com/dfinke/ImportExcel/blob/master/Examples/ExcelDataValidation/MutipleValidations.ps1). Culled from the `tests`.
 
 # What's new 5.4.4
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Install-Module ImportExcel -scope CurrentUser
 Install-Module ImportExcel
 ```
 # What's new
+- Modified Send-SQLDataToExcel so it creates tables and ranges itself; previously it relied on export-excel to do this which cause problems when adding data to an existing sheet (#555)
 - Added new command Add-ExcelDataValidation which will apply different data-validation rules to ranges of cells
 - Changed the export behavior so that (1) attempts to convert to a number only apply if the the value was a string; (2) Nulls are no longer converted to an empty string (3) there is a specific check for URIs and not just text which is a valid URI. Using UNC names in hyperlinks remains problematic.   
 - Changed the behavior of AutoSize in export excel so it only applies to the exported columns. Previously if something was exported next to pre-existing data, AutoSize would resize the whole sheet, potentially undoing things which had been set on the earlier data. If anyone relied on this behavior they will need to explictly tell the sheet to auto size with $sheet.cells.autofitColumns. (where $sheet points to the sheet, it might be $ExcelPackage.Workbook.Worksheets['Name'])

--- a/README.md
+++ b/README.md
@@ -52,13 +52,6 @@ Install-Module ImportExcel -scope CurrentUser
 ```PowerShell
 Install-Module ImportExcel
 ```
-# What's new this time. 
-- Performance improvement to Export-Excel see #506 and #555. This has meant taking code in Add-CellValue back into process the body of Export-Excel, as the overhead of calling the function was greater than time executing the code inside it. [Blog post to follow](https://jamesone111.wordpress.com). Some tests are showing a ~10x speed increase. #572 was about a broken #region tag in this part of the code and that has been cleaned up in the process. 
-- Export-Excel now has an `-InputObject` parameter (this was previously `-TargetData` , which is now an alias for InputObject).
- If the `inputobject` is an array, each item will be inserted, so you can run `export-excel -inputobject $x` rather than `$x | Export-Excel`, and if it is a `system.data.datatable` object it will be inserted directly rather than cell-by-cell. Send-SQLDataToExcel takes advantage of this new functionality. 
-- Export-Excel previously assumed `-Now` if there were no other parameters, it will now assume `-Now` if there is no `-Path` or `-ExcelPackage`.     
-- The .PSD1 file now itemizes the items exported by the module (#557) 
-
 # What's new 5.4.5
 
 Thank you to [James O'Neill](https://github.com/jhoneill) for the great additions.

--- a/Send-SqlDataToExcel.ps1
+++ b/Send-SqlDataToExcel.ps1
@@ -1,279 +1,173 @@
 ﻿Function Send-SQLDataToExcel {
-    <#
-        .SYNOPSIS
-            Inserts a DataTable - returned by SQL query into an ExcelSheet, more efficiently than sending it via Export-Excel
-        .DESCRIPTION
-            This command can accept a data table object or take a SQL statement and run it against a database connection.
-            If running a SQL statement, the accepts either
-            * an object representing a session with a SQL server or ODBC database, or
-            * a connection String to make a session.
-            The command takes most of the parameters of Export-Excel, and after inserting the table into the worksheet it
-            calls Export-Excel to carry out other tasks on the sheet. It is more efficient to do this than to get data-rows
-             and pipe them into Export-Excel, stripped off the database 'housekeeping' properties.
-        .PARAMETER DataTable
-            A System.Data.DataTable object containing the data to be inserted into the spreadsheet without running a query.
-        .PARAMETER Session
-            An active ODBC Connection or SQL connection object representing a session with a database which will be queried to get the data .
-        .PARAMETER Connection
-            A database connection string to be used to create a database session; either
-            * A Data source name written in the form DSN=ODBC_Data_Source_Name, or
-            * A full odbc or SQL Connection string, or
-            * The name of a SQL server.
-        .PARAMETER MSSQLServer
-            Specifies the connection string is for SQL server, not ODBC.
-        .PARAMETER SQL
-            The SQL query to run against the session which was passed in -Session or set up from -Connection.
-        .PARAMETER Database
-           Switches to a specific database on a SQL server.
-        .PARAMETER QueryTimeout
-            Override the default query time of 30 seconds.
-        .PARAMETER Path
-            Path to a new or existing .XLSX file.
-        .PARAMETER WorkSheetName
-            The name of a sheet within the workbook - "Sheet1" by default.
-        .PARAMETER KillExcel
-            Closes Excel - prevents errors writing to the file because Excel has it open.
-        .PARAMETER Title
-            Text of a title to be placed in the top left cell.
-        .PARAMETER TitleBold
-            Sets the title in boldface type.
-        .PARAMETER TitleSize
-            Sets the point size for the title.
-        .PARAMETER TitleBackgroundColor
-            Sets the cell background color for the title cell.
-        .PARAMETER TitleFillPattern
-            Sets the fill pattern for the title cell.
-        .PARAMETER Password
-            Sets password protection on the workbook.
-        .PARAMETER IncludePivotTable
-            Adds a Pivot table using the data in the worksheet.
-        .PARAMETER PivotTableName
-            If a Pivot table is created from command line parameters, specificies the name of the new sheet holding the pivot. If Omitted this will be "WorksheetName-PivotTable"
-        .PARAMETER PivotRows
-            Name(s) columns from the spreadhseet which will provide the Row name(s) in a pivot table created from command line parameters.
-        .PARAMETER PivotColumns
-            Name(s) columns from the spreadhseet which will provide the Column name(s) in a pivot table created from command line parameters.
-        .PARAMETER PivotFilter
-            Name(s) columns from the spreadhseet which will provide the Filter name(s) in a pivot table created from command line parameters.
-        .PARAMETER PivotData
-            In a pivot table created from command line parameters, the fields to use in the table body is given as a Hash table in the form ColumnName = Average|Count|CountNums|Max|Min|Product|None|StdDev|StdDevP|Sum|Var|VarP .
-        .PARAMETER PivotDataToColumn
-            If there are multiple datasets in a PivotTable, by default they are shown seperatate rows under the given row heading; this switch makes them seperate columns.
-        .PARAMETER NoTotalsInPivot
-            In a pivot table created from command line parameters, prevents the addition of totals to rows and columns.
-        .PARAMETER IncludePivotChart
-            Include a chart with the Pivot table - implies -IncludePivotTable.
-        .PARAMETER ChartType
-            The type for Pivot chart (one of Excel's defined chart types)
-        .PARAMETER NoLegend
-            Exclude the legend from the pivot chart.
-        .PARAMETER ShowCategory
-            Add category labels to the pivot chart.
-        .PARAMETER ShowPercent
-            Add Percentage labels to the pivot chart.
-        .PARAMETER PivotTableDefinition
-            Instead of describing a single pivot table with mutliple commandline paramters; you can use a HashTable in the form PivotTableName = Definition;
-            Definition is itself a hashtable with Sheet PivotTows, PivotColumns, PivotData, IncludePivotChart and ChartType values.
-        .PARAMETER ConditionalFormat
-            One or more conditional formatting rules defined with New-ConditionalFormattingIconSet.
-        .PARAMETER ConditionalText
-            Applies a 'Conditional formatting rule' in Excel on all the cells. When specific conditions are met a rule is triggered.
-          .PARAMETER BoldTopRow
-            Makes the top Row boldface.
-        .PARAMETER NoHeader
-            Does not put field names at the top of columns.
-        .PARAMETER RangeName
-            Makes the data in the worksheet a named range.
-        .PARAMETER AutoNameRange
-            Makes each column a named range.
-        .PARAMETER TableName
-            Makes the data in the worksheet a table with a name applies a style to it. Name must not contain spaces.
-        .PARAMETER TableStyle
-            Selects the style for the named table - defaults to 'Medium6'.
-        .PARAMETER BarChart
-            Creates a "quick" bar chart using the first text column as labels and the first numeric column as values
-        .PARAMETER ColumnChart
-            Creates a "quick" column chart using the first text column as labels and the first numeric column as values
-        .PARAMETER LineChart
-            Creates a "quick" line chart using the first text column as labels and the first numeric column as values
-        .PARAMETER PieChart
-            Creates a "quick" pie chart using the first text column as labels and the first numeric column as values
-        .PARAMETER ExcelChartDefinition
-            A hash table containing ChartType, Title, NoLegend, ShowCategory, ShowPercent, Yrange, Xrange and SeriesHeader for one or more [non-pivot] charts.
-        .PARAMETER StartRow
-            Row to start adding data. 1 by default. Row 1 will contain the title if any. Then headers will appear (Unless -No header is specified) then the data appears.
-        .PARAMETER StartColumn
-            Column to start adding data - 1 by default.
-        .PARAMETER FreezeTopRow
-            Freezes headers etc. in the top row.
-        .PARAMETER FreezeFirstColumn
-            Freezes titles etc. in the left column.
-        .PARAMETER FreezeTopRowFirstColumn
-             Freezes top row and left column (equivalent to Freeze pane 2,2 ).
-        .PARAMETER FreezePane
-             Freezes panes at specified coordinates (in the form  RowNumber , ColumnNumber).
-        .PARAMETER AutoFilter
-            Enables the 'Filter' in Excel on the complete header row. So users can easily sort, filter and/or search the data in the select column from within Excel.
-        .PARAMETER AutoSize
-            Sizes the width of the Excel column to the maximum width needed to display all the containing data in that cell.
-        .PARAMETER Show
-            Opens the Excel file immediately after creation. Convenient for viewing the results instantly without having to search for the file first.
-        .PARAMETER CellStyleSB
-            A script block which is run at the end of the process to apply styles to cells (although it can be used for other purposes).
-            The script block is given three paramaters; an object containing the current worksheet, the Total number of Rows and the number of the last column.
-        .PARAMETER ReturnRange
-            If specified, Export-Excel returns the range of added cells in the format "A1:Z100"
-        .PARAMETER PassThru
-            If specified, Export-Excel returns an object representing the Excel package without saving the package first. To save it you need to call the save or Saveas method or send it back to Export-Excel.
-
+        <#
+      .SYNOPSIS
+        Inserts a DataTable - returned by a SQL query - into an ExcelSheet
+      .DESCRIPTION
+        This command takes a SQL statement and run it against a database connection; for the connection it accepts either
+        * an object representing a session with a SQL server or ODBC database, or
+        * a connection string to make a session (if -MSSQLServer is specified it uses the SQL Native client,
+          and -Connection can be a server name instead of a detailed connection string. Without this switch it uses ODBC)
+        The command takes all the parameters of Export-Excel, except for -InputObject (alias TargetData); after
+        fetching the data it calls Export-Excel with the data as the value of InputParameter and whichever of
+        Export-Excel's parameters it was passed; for details of these parameters see the help for Export-Excel.
+      .PARAMETER Session
+        An active ODBC Connection or SQL connection object representing a session with a database which will be queried to get the data .
+      .PARAMETER Connection
+        A database connection string to be used to create a database session; either
+        * A Data source name written in the form DSN=ODBC_Data_Source_Name, or
+        * A full ODBC or SQL Native Client Connection string, or
+        * The name of a SQL server.
+      .PARAMETER MSSQLServer
+        Specifies the connection string is for SQL server, not ODBC.
+      .PARAMETER SQL
+        The SQL query to run against the session which was passed in -Session or set up from -Connection.
+      .PARAMETER Database
+        Switches to a specific database on a SQL server.
+      .PARAMETER QueryTimeout
+        Override the default query time of 30 seconds.
+      .PARAMETER DataTable
+        A System.Data.DataTable object containing the data to be inserted into the spreadsheet without running a query.
+        This remains supported to avoid breaking older scripts, but if you have a DataTable object you can pass the it
+        into Export-Excel using -InputObject.
       .EXAMPLE
         C:\> Send-SQLDataToExcel -MsSQLserver -Connection localhost -SQL  "select name,type,type_desc from [master].[sys].[all_objects]" -Path .\temp.xlsx -WorkSheetname master -AutoSize -FreezeTopRow -AutoFilter -BoldTopRow
 
         Connects to the local SQL server and selects 3 columns from [Sys].[all_objects] and exports then to a sheet named master with some basic header management
       .EXAMPLE
+        C:\> $dbPath = 'C:\Users\James\Documents\Database1.accdb'
+        C:\> $Connection = "Driver={Microsoft Access Driver (*.mdb, *.accdb)};Dbq=$dbPath;"
         C:\> $SQL="SELECT top 25 Name,Length  From TestData ORDER BY Length DESC"
-        C:\> $Connection = ' Driver={Microsoft Access Driver (*.mdb, *.accdb)};Dbq=C:\Users\James\Documents\Database1.accdb;'
 
         C:\> Send-SQLDataToExcel -Connection  $connection -SQL $sql -path .\demo1.xlsx -WorkSheetname "Sizes" -AutoSize
 
-         This declares a SQL statement and creates an  ODBC connection string to read from an Access file and extracts data from it and sends it to a new worksheet
+        This creates an  ODBC connection string to read from an Access file and a SQL Statement to extracts data from it,
+        and sends the resulting data to a new worksheet
 
       .EXAMPLE
-        C:\> $SQL="SELECT top 25 DriverName, Count(RaceDate) as Races, Count(Win) as Wins, Count(Pole) as Poles, Count(FastestLap) as Fastlaps FROM Results GROUP BY DriverName ORDER BY (count(win)) DESC"
-        C:\> $Connection = 'Driver={Microsoft Excel Driver (*.xls, *.xlsx, *.xlsm, *.xlsb)};Dbq=C:\users\James\Documents\f1Results.xlsx;'
+        C:\> $dbPath = 'C:\users\James\Documents\f1Results.xlsx'
+        C:\> $Connection = "Driver={Microsoft Excel Driver (*.xls, *.xlsx, *.xlsm, *.xlsb)};Dbq=$dbPath;"
+        C:\> $SQL="SELECT top 25 DriverName, Count(RaceDate) as Races, Count(Win) as Wins, Count(Pole) as Poles, Count(FastestLap) as Fastlaps " +
+                   " FROM Results  GROUP BY DriverName ORDER BY (count(win)) DESC"
 
-        C:\> Send-SQLDataToExcel -Connection  $connection -SQL $sql -path .\demo1.xlsx -WorkSheetname "Winners" -AutoSize -AutoNameRange -ConditionalFormat @{DataBarColor="Blue"; Range="Wins"}
+        C:\> Send-SQLDataToExcel -Connection  $connection -SQL $sql -path .\demo2.xlsx -WorkSheetname "Winners" -AutoSize -AutoNameRange -ConditionalFormat @{DataBarColor="Blue"; Range="Wins"}
 
-        This declares a SQL statement and creates an  ODBC connection string to read from an Excel file, it then runs the statement and outputs the resulting data to a new spreadsheet.
+        Similar to the previous example this creates a connection string, this time for an Excel file, and runs
+        a SQL statement to get a list of motor-racing results, outputting the resulting data to a new spreadsheet.
         The spreadsheet is formatted and a data bar added to show make the drivers' wins clearer.
         (the F1 results database is available from https://1drv.ms/x/s!AhfYu7-CJv4ehNdZWxJE9LMAX_N5sg )
       .EXAMPLE
-        C:\> $SQL = "SELECT top 25 DriverName, Count(RaceDate) as Races, Count(Win) as Wins, Count(Pole) as Poles, Count(FastestLap) as Fastlaps FROM Results GROUP BY DriverName ORDER BY (count(win)) DESC"
-        C:\> Get-SQL -Session F1 -excel -Connection "C:\Users\mcp\OneDrive\public\f1\f1Results.xlsx" -sql $sql -OutputVariable Table | out-null
+        C:\> $dbPath = 'C:\users\James\Documents\f1Results.xlsx'
+        C:\> $SQL = "SELECT top 25 DriverName, Count(RaceDate) as Races, Count(Win) as Wins, Count(Pole) as Poles, Count(FastestLap) as Fastlaps " +
+                     " FROM Results GROUP BY DriverName ORDER BY (count(win)) DESC"
+        C:\> Get-SQL -Session F1 -excel -Connection $dbPath -sql $sql -OutputVariable Table | out-null
 
         C:\> Send-SQLDataToExcel -DataTable $Table -Path ".\demo3.xlsx" -WorkSheetname Gpwinners -autosize  -TableName winners -TableStyle Light6 -show
 
-        This uses Get-SQL (at least V1.1 - download from the gallery with Install-Module -Name GetSQL - note the function is Get-SQL the module is GetSQL without the "-" )
-        to simplify making database connections and building /submitting SQL statements.
-        Here it uses the same SQL statement as before; -OutputVariable leaves a System.Data.DataTable object in $table
+        This uses Get-SQL (at least V1.1 - download from the PowerShell gallery with Install-Module -Name GetSQL -
+        note the function is Get-SQL the module is GetSQL without the "-" )
+        Get-SQL simplify making database connections and building /submitting SQL statements.
+        Here Get-SQL uses the same SQL statement as before; -OutputVariable leaves a System.Data.DataTable object in $table
         and Send-SQLDataToExcel puts $table into the worksheet and sets it as an Excel table.
+        The command is equivalent to running
+        C:\>  Export-Excel -inputObject $Table -Path ".\demo3.xlsx" -WorkSheetname Gpwinners -autosize  -TableName winners -TableStyle Light6 -show
+        This is quicker than using
+        C:\> Get-SQL <parameters> | export-excel -ExcludeProperty rowerror,rowstate,table,itemarray,haserrors <parameters>
         (the F1 results database is available from https://1drv.ms/x/s!AhfYu7-CJv4ehNdZWxJE9LMAX_N5sg )
       .EXAMPLE
         C:\> $SQL = "SELECT top 25 DriverName,  Count(Win) as Wins FROM Results GROUP BY DriverName ORDER BY (count(win)) DESC"
-        C:\> Send-SQLDataToExcel -Session $DbSessions["f1"] -SQL $sql -Path  ".\demo3.xlsx" -WorkSheetname Gpwinners -autosize -ColumnChart
+        C:\> Send-SQLDataToExcel -Session $DbSessions["f1"] -SQL $sql -Path  ".\demo3.xlsx" -WorkSheetname Gpwinners  -ClearSheet -autosize -ColumnChart
 
-        Like the previous example, this uses Get-SQL (download from the gallery with Install-Module -Name GetSQL). It uses the connection which Get-SQL made rather than an ODFBC connection string
+        Like the previous example, this uses Get-SQL (download from the gallery with Install-Module -Name GetSQL).
+        It uses the database session which Get-SQL created, rather than an ODBC connection string.
+        The Session parameter can either be a object (as shown here), or the name used by Get-SQL ("F1" in this case).
         Here the data is presented as a quick chart.
       .EXAMPLE
-        C:\>  Send-SQLDataToExcel -path .\demo3.xlsx -WorkSheetname "LR" -Connection "DSN=LR" -sql "SELECT name AS CollectionName FROM AgLibraryCollection Collection ORDER BY CollectionName"
+        C:\>  Send-SQLDataToExcel -path .\demo4.xlsx -WorkSheetname "LR" -Connection "DSN=LR" -sql "SELECT name AS CollectionName FROM AgLibraryCollection Collection ORDER BY CollectionName"
 
         This example uses an Existing ODBC datasource name "LR" which maps to an adobe lightroom database and gets a list of collection names into a worksheet
+
+    .Link
+        Export-Excel
     #>
-    [CmdletBinding()]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingPlainTextForPassword","")]
-     param (
-        [Parameter(ParameterSetName="SQLConnection", Mandatory=$true)]
-        [Parameter(ParameterSetName="ODBCConnection",Mandatory=$true)]
+    [CmdletBinding(DefaultParameterSetName="none")]
+    param (
+        [Parameter(ParameterSetName="SQLConnection",   Mandatory=$true)]
+        [Parameter(ParameterSetName="ODBCConnection",  Mandatory=$true)]
         $Connection,
-        [Parameter(ParameterSetName="ExistingSession",Mandatory=$true)]
-        [System.Data.Common.DbConnection]$Session,
-        [Parameter(ParameterSetName="SQLConnection",Mandatory=$true)]
+        [Parameter(ParameterSetName="ExistingSession", Mandatory=$true)]
+        $Session,
+        [Parameter(ParameterSetName="SQLConnection",   Mandatory=$true)]
         [switch]$MsSQLserver,
         [Parameter(ParameterSetName="SQLConnection")]
         [String]$DataBase,
-        [Parameter(ParameterSetName="SQLConnection", Mandatory=$true)]
-        [Parameter(ParameterSetName="ODBCConnection",Mandatory=$true)]
-        [Parameter(ParameterSetName="ExistingSession",Mandatory=$true)]
+        [Parameter(ParameterSetName="SQLConnection",   Mandatory=$true)]
+        [Parameter(ParameterSetName="ODBCConnection",  Mandatory=$true)]
+        [Parameter(ParameterSetName="ExistingSession", Mandatory=$true)]
         [string]$SQL,
         [int]$QueryTimeout,
-        [Parameter(ParameterSetName="Pre-FetchedData",Mandatory=$true)]
-        [System.Data.DataTable]$DataTable,
-        $Path,
-        [String]$WorkSheetname = 'Sheet1',
-        [Switch]$KillExcel,
-        [Switch]$Show,
-        [String]$Title,
-        [OfficeOpenXml.Style.ExcelFillStyle]$TitleFillPattern = 'None',
-        [Switch]$TitleBold,
-        [Int]$TitleSize = 22,
-        $TitleBackgroundColor,
-        [String]$Password,
-        [Hashtable]$PivotTableDefinition,
-        [Switch]$IncludePivotTable,
-        [String[]]$PivotRows,
-        [String[]]$PivotColumns,
-        $PivotData,
-        [String[]]$PivotFilter,
-        [Switch]$PivotDataToColumn,
-        [Switch]$NoTotalsInPivot,
-        [Switch]$IncludePivotChart,
-        [OfficeOpenXml.Drawing.Chart.eChartType]$ChartType = 'Pie',
-        [Switch]$NoLegend,
-        [Switch]$ShowCategory,
-        [Switch]$ShowPercent,
-        [Switch]$AutoSize,
-        [Switch]$FreezeTopRow,
-        [Switch]$FreezeFirstColumn,
-        [Switch]$FreezeTopRowFirstColumn,
-        [Int[]]$FreezePane,
-        [Switch]$AutoFilter,
-        [Switch]$BoldTopRow,
-        [Switch]$NoHeader,
-        [String]$RangeName,
-        [String]$TableName,
-        [OfficeOpenXml.Table.TableStyles]$TableStyle = 'Medium6',
-        [Switch]$Barchart,
-        [Switch]$PieChart,
-        [Switch]$LineChart ,
-        [Switch]$ColumnChart ,
-        [Object[]]$ExcelChartDefinition,
-        [Switch]$AutoNameRange,
-        [Object[]]$ConditionalFormat,
-        [Object[]]$ConditionalText,
-        [ScriptBlock]$CellStyleSB,
-        [Int]$StartRow    = 1,
-        [Int]$StartColumn = 1,
-        [Switch]$ReturnRange,
-        [Switch]$Passthru
+        [Parameter(ParameterSetName="Pre-FetchedData", Mandatory=$true)]
+        [System.Data.DataTable]$DataTable
     )
-
-    #We were either given a session object or a connection string (with, optionally a MSSQLServer parameter)
-    # If we got -MSSQLServer, create a SQL connection, if we didn't but we got -Connection create an ODBC connection
-    if     ($MsSQLserver -and $Connection) {
-            if ($Connection -notmatch "=") {$Connection = "server=$Connection;trusted_connection=true;timeout=60"}
-            $Session     = New-Object -TypeName System.Data.SqlClient.SqlConnection  -ArgumentList $Connection
-            if ($Session.State -ne 'Open') {$Session.Open()}
-            if ($DataBase) {$Session.ChangeDatabase($DataBase) }
-    }
-    elseif ($Connection)  {
-            $Session     = New-Object -TypeName System.Data.Odbc.OdbcConnection      -ArgumentList $Connection ; $Session.ConnectionTimeout = 30
-    }
-    if ($Session) {
-        #A session was either passed in or just created. If it's a SQL one make a SQL DataAdapter, otherwise make an ODBC one
-        if ($Session.GetType().name -match "SqlConnection") {
-            $dataAdapter = New-Object -TypeName System.Data.SqlClient.SqlDataAdapter -ArgumentList (
-                           New-Object -TypeName System.Data.SqlClient.SqlCommand     -ArgumentList $SQL, $Session)
+#Import the parameters from Export-Excel, we will pass InputObject, and we have the common parameters so exclude those,
+#and re-write the [Parmameter] attribute on each one to avoid parameterSetName here competing with the settings in Export excel.
+#The down side of this that impossible parameter combinations won't be filtered out and need to be caught later.
+    DynamicParam {
+        $ParameterAttribute  =                        "System.Management.Automation.ParameterAttribute"
+        $RuntimeDefinedParam =                        "System.Management.Automation.RuntimeDefinedParameter"
+        $paramDictionary     =    New-Object -TypeName System.Management.Automation.RuntimeDefinedParameterDictionary
+        $attributeCollection =    New-Object -TypeName System.Collections.ObjectModel.Collection[System.Attribute]
+        $attributeCollection.Add((New-Object -TypeName $ParameterAttribute -Property @{ ParameterSetName = "__AllParameterSets" ;Mandatory = $false}))
+        foreach ($P in (Get-Command -Name Export-Excel).Parameters.values.where({$_.name -notmatch 'Verbose|Debug|Action$|Variable$|Buffer$|TargetData$|InputObject$'}))  {
+            $paramDictionary.Add($p.Name, (New-Object -TypeName $RuntimeDefinedParam -ArgumentList $p.name, $p.ParameterType, $attributeCollection ) )
         }
-        else {
-            $dataAdapter = New-Object -TypeName System.Data.Odbc.OdbcDataAdapter     -ArgumentList (
-                           New-Object -TypeName System.Data.Odbc.OdbcCommand         -ArgumentList $SQL, $Session )
+        return $paramDictionary
+    }
+    process {
+        #Dynamic params mean we can get passed parameter combination Export-Excel will reject, so throw here, rather than get data and then have Export-Excel error.
+        if ($PSBoundParameters.Path -and $PSBoundParameters.ExcelPackage) {
+            throw 'Parameter error: you cannot specify both a path and an Excel Package.'
+            return
         }
-        if ($QueryTimeout) {$dataAdapter.SelectCommand.CommandTimeout = $QueryTimeout}
+        if ($PSBoundParameters.AutoFilter -and ($PSBoundParameters.TableName -or $PSBoundParameters.TableStyle)) {
+            Write-Warning "Tables are automatically auto-filtered, -AutoFilter will be ignored"
+            [void]$PSBoundParameters.Remove('AutoFilter')
+        }
+        #We were either given a session object or a connection string (with, optionally a MSSQLServer parameter)
+        #If we got -MSSQLServer, create a SQL connection, if we didn't but we got -Connection create an ODBC connection
+        if     ($MsSQLserver -and $Connection) {
+                if ($Connection -notmatch '=') {$Connection = "server=$Connection;trusted_connection=true;timeout=60"}
+                $Session     = New-Object -TypeName System.Data.SqlClient.SqlConnection  -ArgumentList $Connection
+                if ($Session.State -ne 'Open') {$Session.Open()}
+                if ($DataBase) {$Session.ChangeDatabase($DataBase) }
+        }
+        elseif ($Connection)  {
+                $Session     = New-Object -TypeName System.Data.Odbc.OdbcConnection      -ArgumentList $Connection ; $Session.ConnectionTimeout = 30
+        }
+        if     ($Session) {
+            #A session was either passed in or just created. If it's a SQL one make a SQL DataAdapter, otherwise make an ODBC one
+            if ($Session -is [String] -and $Global:DbSessions[$Session]) {$Session = $Global:DbSessions[$Session]}
+            if ($Session.GetType().name -match "SqlConnection") {
+                $dataAdapter = New-Object -TypeName System.Data.SqlClient.SqlDataAdapter -ArgumentList (
+                               New-Object -TypeName System.Data.SqlClient.SqlCommand     -ArgumentList $SQL, $Session)
+            }
+            else {
+                $dataAdapter = New-Object -TypeName System.Data.Odbc.OdbcDataAdapter     -ArgumentList (
+                               New-Object -TypeName System.Data.Odbc.OdbcCommand         -ArgumentList $SQL, $Session )
+            }
+            if ($QueryTimeout) {$dataAdapter.SelectCommand.CommandTimeout = $QueryTimeout}
 
-        #Both adapter types output the same kind of table, create one and fill it from the adapter
-        $DataTable       = New-Object -TypeName System.Data.DataTable
-        $rowCount        = $dataAdapter.fill($dataTable)
-        Write-Verbose -Message "Query returned $rowCount row(s)"
+            #Both adapter types output the same kind of table, create one and fill it from the adapter
+            $DataTable       = New-Object -TypeName System.Data.DataTable
+            $rowCount        = $dataAdapter.fill($dataTable)
+            Write-Verbose -Message "Query returned $rowCount row(s)"
+        }
+        if     ($DataTable.Rows.Count) {
+            #Call export-excel removing parameters which relate to the SQL query, and keeping the rest.
+            'Connection' , 'Database'  , 'Session' , 'MsSQLserver' , 'SQL'  , 'DataTable'  , 'QueryTimeout'  | ForEach-Object {$null = $PSBoundParameters.Remove($_) }
+            Export-Excel  @PSBoundParameters -InputObject $DataTable
+        }
+        else   {Write-Warning -Message ' No Data to insert.' }
+        #If we were passed a connection and opened a session,  close that session.
+        if     ($Connection)  {$Session.close() }
     }
-    if ($DataTable.Rows.Count) {
-        #ExportExcel user a -NoHeader parameter so that's what we use here, but needs to be the other way around.
-
-        #Call export-excel with any parameters which don't relate to the SQL query
-
-        "Connection", "Database" , "Session", "MsSQLserver", "SQL" , "DataTable" | ForEach-Object {$null = $PSBoundParameters.Remove($_) }
-        Export-Excel  @PSBoundParameters -InputObject $DataTable
-    }
-    else {Write-Warning -Message "No Data to insert."}
-    #If we were passed a connection and opened a session,  close that session.
-    if ($Connection)  {$Session.close() }
 }

--- a/__tests__/Copy-ExcelWorksheet.Tests.ps1
+++ b/__tests__/Copy-ExcelWorksheet.Tests.ps1
@@ -4,8 +4,8 @@ Remove-item -Path $path1, $path2  -ErrorAction SilentlyContinue
 
 $ProcRange = Get-Process | Export-Excel $path1 -DisplayPropertySet -WorkSheetname Processes -ReturnRange
 
-if ((Get-Culture).NumberFormat.CurrencySymbol -eq "�") {$OtherCurrencySymbol = "$"}
-else {$OtherCurrencySymbol = "�"}
+if ((Get-Culture).NumberFormat.CurrencySymbol -eq "£") {$OtherCurrencySymbol = "$"}
+else {$OtherCurrencySymbol = "£"}
 [PSCustOmobject][Ordered]@{
     Date             = Get-Date
     Formula1         = '=SUM(F2:G2)'

--- a/__tests__/First10Races.tests.ps1
+++ b/__tests__/First10Races.tests.ps1
@@ -54,7 +54,7 @@ Describe "Creating small named ranges with hyperlinks" {
 
         $excel = Open-ExcelPackage $path
         $sheet = $excel.Workbook.Worksheets[1]
-        $m = $results | measure -sum -Property count
+        $m = $results | Measure-Object -sum -Property count
         $expectedRows = 1 + $m.count + $m.sum
     }
     Context "Creating hyperlinks" {

--- a/__tests__/InputItemParameter.tests.ps1
+++ b/__tests__/InputItemParameter.tests.ps1
@@ -1,0 +1,79 @@
+Describe "Exporting with -Inputobject" {
+    BeforeAll {
+        $path = "$env:TEMP\Results.xlsx"
+        Remove-Item -Path $path -ErrorAction SilentlyContinue
+        #Read race results, and group by race name : export 1 row to get headers, leaving enough rows aboce to put in a link for each race
+        $results = ((Get-Process) + (Get-Process -id $PID)) | Select-Object -last  10 -Property Name, cpu, pm, handles, StartTime
+        $DataTable = [System.Data.DataTable]::new('Test')
+        [void]$DataTable.Columns.Add('Name')
+        [void]$DataTable.Columns.Add('CPU', [double])
+        [void]$DataTable.Columns.Add('PM',  [Long])
+        [void]$DataTable.Columns.Add('Handles',  [Int])
+        [void]$DataTable.Columns.Add('StartTime', [DateTime])
+        foreach ($r in $results) {
+            [void]$DataTable.Rows.Add($r.name, $r.CPU, $R.PM, $r.Handles, $r.StartTime)
+        }
+        export-excel        -Path $path -InputObject $results   -WorksheetName Sheet1 -RangeName "Whole"
+        export-excel        -Path $path -InputObject $DataTable -WorksheetName Sheet2 -AutoNameRange
+        Send-SQLDataToExcel -path $path -DataTable   $DataTable -WorkSheetname Sheet3  -TableName "Data"
+        $excel = Open-ExcelPackage $path
+        $sheet = $excel.Sheet1
+    }
+    Context "Array of processes" {
+        it "Put the correct rows and columns into the sheet                                        " {
+            $sheet.Dimension.Rows                                       | should     be ($results.Count + 1)
+            $sheet.Dimension.Columns                                    | should     be  5
+            $sheet.cells["A1"].Value                                    | should     be "Name"
+            $sheet.cells["E1"].Value                                    | should     be "StartTime"
+            $sheet.cells["A3"].Value                                    | should     be $results[1].Name
+        }
+        it "Created a range for the whole sheet                                                    " {
+            $sheet.Names[0].Name                                        | should     be "Whole"
+            $sheet.Names[0].Start.Address                               | should     be "A1"
+            $sheet.Names[0].End.row                                     | should     be ($results.Count + 1)
+            $sheet.Names[0].End.Column                                  | should     be 5
+        }
+        it "Formatted date fields with date type                                                   " {
+            $sheet.Cells["E11"].Style.Numberformat.NumFmtID             | should     be 22
+        }
+    }
+    $sheet = $excel.Sheet2
+    Context "Table of processes" {
+        it "Put the correct rows and columns into the sheet                                        " {
+            $sheet.Dimension.Rows                                       | should     be ($results.Count + 1)
+            $sheet.Dimension.Columns                                    | should     be  5
+            $sheet.cells["A1"].Value                                    | should     be "Name"
+            $sheet.cells["E1"].Value                                    | should     be "StartTime"
+            $sheet.cells["A3"].Value                                    | should     be $results[1].Name
+        }
+        it "Created named ranges for each column                                                   " {
+            $sheet.Names.count                                          | should     be 5
+            $sheet.Names[0].Name                                        | should     be "Name"
+            $sheet.Names[1].Start.Address                               | should     be "B2"
+            $sheet.Names[2].End.row                                     | should     be ($results.Count + 1)
+            $sheet.Names[3].End.Column                                  | should     be 4
+            $sheet.Names[4].Start.Column                                | should     be 5
+        }
+        it "Formatted date fields with date type                                                   " {
+            $sheet.Cells["E11"].Style.Numberformat.NumFmtID             | should     be 22
+        }
+    }
+    $sheet = $excel.Sheet3
+    Context "Table of processes via Send-SQLDataToExcel" {
+        it "Put the correct rows and columns into the sheet                                        " {
+            $sheet.Dimension.Rows                                       | should     be ($results.Count + 1)
+            $sheet.Dimension.Columns                                    | should     be  5
+            $sheet.cells["A1"].Value                                    | should     be "Name"
+            $sheet.cells["E1"].Value                                    | should     be "StartTime"
+            $sheet.cells["A3"].Value                                    | should     be $results[1].Name
+        }
+        it "Created a table                                                                        " {
+            $sheet.Tables.count                                         | should     be 1
+            $sheet.Tables[0].Name                                       | should     be "Data"
+            $sheet.Tables[0].Columns[4].name                            | should     be "StartTime"
+        }
+        it "Formatted date fields with date type                                                   " {
+            $sheet.Cells["E11"].Style.Numberformat.NumFmtID             | should     be 22
+        }
+    }
+}

--- a/__tests__/Set-Row_Set-Column-SetFormat.tests.ps1
+++ b/__tests__/Set-Row_Set-Column-SetFormat.tests.ps1
@@ -321,7 +321,7 @@ ID,Product,Quantity,Price,Total
 Describe "AutoNameRange data with a single property name" {
     BeforeEach {
         $xlfile = "$Env:TEMP\testNamedRange.xlsx"
-        rm $xlfile -ErrorAction SilentlyContinue
+        Remove-Item $xlfile -ErrorAction SilentlyContinue
     }
 
     it "Should have a single item as a named range" {


### PR DESCRIPTION
I had to roll back the changes I made to the readme so github would accept the changes could be merged. So here .... 
# What's new this time. 
- **Performance improvement to Export-Excel** see #506 and #555. This has meant taking code in `Add-CellValue` back into process block of Export-Excel, as the overhead of calling the function was a lot greater than time executing the code inside it. [Blog post to follow](https://jamesone111.wordpress.com). Some tests are showing a ~10x speed increase. #572 was about a broken #region tag in this part of the code and that has been cleaned up in the process. 
- Export-Excel now has an `-InputObject` parameter (this was previously `-TargetData` , which is now an alias for InputObject).
 If the `inputobject` is an array, each item will be inserted, so you can run `export-excel -inputobject $x` rather than `$x | Export-Excel`, and if it is a `system.data.datatable` object it will be inserted directly rather than cell-by-cell. Send-SQLDataToExcel takes advantage of this new functionality. There are simple tests for these new items
- Export-Excel previously assumed `-Now` if there were no other parameters, it will now assume `-Now` if there is no `-Path` or `-ExcelPackage`.     
- The .PSD1 file now itemizes the items exported by the module (#557) 
