### PR TITLE
Fix Test accidentally closing focused window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,5 +61,6 @@ testCCFMT.ps1
 testHide.ps1
 ImportExcel.zip
 .vscode/launch.json
+.vscode/settings.json
 
 ~$*

--- a/__tests__/Compare-WorkSheet.tests.ps1
+++ b/__tests__/Compare-WorkSheet.tests.ps1
@@ -51,8 +51,15 @@ Describe "Compare Worksheet" {
     Context "Setting the background to highlight different rows, use of grid view." {
         BeforeAll {
             $useGrid =  ($PSVersionTable.PSVersion.Major -LE 5)
-            $null = Compare-WorkSheet "$env:temp\Server1.xlsx" "$env:temp\Server2.xlsx" -BackgroundColor ([System.Drawing.Color]::LightGreen) -GridView:$useGrid
-            if ($useGrid) {Start-Sleep -sec 5; [System.Windows.Forms.SendKeys]::Sendwait("%{F4}") }
+            if ($useGrid) {
+                $ModulePath = (Get-Command -Name 'Compare-WorkSheet').Module.Path
+                $PowerShellExec = if ($PSEdition -eq 'Core') {'pwsh.exe'} else {'powershell.exe'}
+                $PowerShellPath = Join-Path -Path $PSHOME -ChildPath $PowerShellExec
+                . $PowerShellPath -Command ("Import-Module $ModulePath; " + '$null = Compare-WorkSheet "$env:temp\Server1.xlsx" "$env:temp\Server2.xlsx" -BackgroundColor ([System.Drawing.Color]::LightGreen) -GridView; Start-Sleep -sec 5')
+            }
+            else {
+                $null = Compare-WorkSheet "$env:temp\Server1.xlsx" "$env:temp\Server2.xlsx" -BackgroundColor ([System.Drawing.Color]::LightGreen) -GridView:$useGrid
+            }
             $xl1  = Open-ExcelPackage -Path "$env:temp\Server1.xlsx"
             $xl2  = Open-ExcelPackage -Path "$env:temp\Server2.xlsx"
             $s1Sheet = $xl1.Workbook.Worksheets[1]


### PR DESCRIPTION
The test call the command `Compare-WorkSheet` with the switch `-GridView` then sends "Alt + F4" to the active window.
The problem is that if the `Out-GridView` is not in focus the test will close the focused window whether it's the `Out-GridView` or not. (Usually it closes my VSCode).
The fix open the GridView in a new PowerShell instance that closes itself when it finished. 