### PR TITLE
TableStyle is set to Medium6 but ignored

### DIFF
--- a/Export-Excel.ps1
+++ b/Export-Excel.ps1
@@ -483,7 +483,7 @@
         [String]$TableName,
         [Parameter(ParameterSetName = 'Table')]
         [Parameter(ParameterSetName = 'PackageTable')]
-        [OfficeOpenXml.Table.TableStyles]$TableStyle = 'Medium6',
+        [OfficeOpenXml.Table.TableStyles]$TableStyle,
         [Switch]$Barchart,
         [Switch]$PieChart,
         [Switch]$LineChart ,
@@ -1369,7 +1369,7 @@ function Add-ExcelTable {
         if     ($PSBoundParameters.ContainsKey('ShowLastColumn'))    {$tbl.ShowLastColumn    = [bool]$ShowLastColumn}
         if     ($PSBoundParameters.ContainsKey('ShowRowStripes'))    {$tbl.ShowRowStripes    = [bool]$ShowRowStripes}
         if     ($PSBoundParameters.ContainsKey('ShowColumnStripes')) {$tbl.ShowColumnStripes = [bool]$ShowColumnStripes}
-        if     ($PSBoundParameters.ContainsKey('TableStyle'))        {$tbl.TableStyle        = $TableStyle}
+        $tbl.TableStyle = $TableStyle
 
         if ($PassThru) {return $tbl}
     }

--- a/__tests__/Export-Excel.Tests.ps1
+++ b/__tests__/Export-Excel.Tests.ps1
@@ -966,8 +966,9 @@ Describe ExportExcel {
             $ws.Tables["FileSize"].Address.Address                      | Should     be "G2:H16" #Insert at row 2, Column 7, 14 rows x 2 columns of data
             $ws.Tables["FileSize"].StyleName                            | Should     be "TableStyleMedium2"
         }
-        it "Created the ExtSize  table in the right place with the right size                      " {
+        it "Created the ExtSize  table in the right place with the right size and style            " {
             $ws.Tables["ExtSize"].Address.Address                      | Should      be "A2:B14" #tile, then 12 rows x 2 columns of data
+            $ws.Tables["ExtSize"].StyleName                            | Should      be "TableStyleMedium6"
         }
         it "Created the ExtCount table in the right place with the right size                      " {
             $ws.Tables["ExtCount"].Address.Address                      | Should     be "D2:E12" #title, then 10 rows x 2 columns of data


### PR DESCRIPTION
Export-Excel help gives the following info:
```
        .PARAMETER TableStyle
            Selects the style for the named table - defaults to 'Medium6'.
```
We define the default in Export-Excel `[OfficeOpenXml.Table.TableStyles]$TableStyle = 'Medium6',` then ignoring it `if ($PSBoundParameters.ContainsKey('TableStyle'))`
Then define it again in `Add-ExcelTable` and then ignore it again.

So I remove the definition from Export-Excel as it is redundant and stopped ignoring it in Add-ExcelTable