### PR TITLE
Double DataTable performance

### DIFF
--- a/AddDataValidation.ps1
+++ b/AddDataValidation.ps1
@@ -64,7 +64,7 @@
         [String]$NoBlank
     )
     if  ($Range -is [Array])  {
-        [void]$PSBoundParameters.Remove("Range")
+        $null = $PSBoundParameters.Remove("Range")
         $Range | Add-ExcelDataValidationRule @PSBoundParameters
     }
     else {

--- a/ConvertExcelToImageFile.ps1
+++ b/ConvertExcelToImageFile.ps1
@@ -35,15 +35,15 @@
         Write-Progress -Activity "Exporting $range of $workSheetname in $Path" -Status "Opening Workbook and copying data"
         $xlWbk  = $xlApp.Workbooks.Open($Path)
         $xlWbk.Worksheets($workSheetname).Select()
-        $xlWbk.ActiveSheet.Range($range).Select() | Out-Null
-        $xlApp.Selection.Copy()                   | Out-Null
+        $null = $xlWbk.ActiveSheet.Range($range).Select()
+        $null = $xlApp.Selection.Copy()
         Write-Progress -Activity "Exporting $range of $workSheetname in $Path" -Status "Saving copied data"
         # Get-Clipboard came in with PS5. Older versions can use [System.Windows.Clipboard] but it is ugly.
         $image  = Get-Clipboard -Format Image
         $image.Save($destination, $Format)
         Write-Progress -Activity "Exporting $range of $workSheetname in $Path" -Status "Closing Excel"
-        $xlWbk.ActiveSheet.Range("a1").Select()   | Out-Null
-        $xlApp.Selection.Copy()                   | Out-Null
+        $null = $xlWbk.ActiveSheet.Range("a1").Select()
+        $null = $xlApp.Selection.Copy()
         $xlApp.Quit()
         Write-Progress -Activity "Exporting $range of $workSheetname in $Path" -Completed
         if ($show) {Start-Process -FilePath $destination}

--- a/ConvertToExcelXlsx.ps1
+++ b/ConvertToExcelXlsx.ps1
@@ -50,7 +50,7 @@ Function ConvertTo-ExcelXlsx {
         }
 
         $Excel.Visible = $false
-        $Excel.Workbooks.Open($xlsFile.FullName) | Out-Null
+        $null = $Excel.Workbooks.Open($xlsFile.FullName)
         $Excel.ActiveWorkbook.SaveAs($xlsxPath, $xlFixedFormat)
         $Excel.ActiveWorkbook.Close()
         $Excel.Quit()

--- a/Export-Excel.ps1
+++ b/Export-Excel.ps1
@@ -1054,9 +1054,9 @@
                 }
                 try {
                     $TempZipPath = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ([System.IO.Path]::GetRandomFileName())
-                    [io.compression.zipfile]::ExtractToDirectory($pkg.File, $TempZipPath)  | Out-Null
+                    $null = [io.compression.zipfile]::ExtractToDirectory($pkg.File, $TempZipPath)
                     Remove-Item $pkg.File -Force
-                    [io.compression.zipfile]::CreateFromDirectory($TempZipPath, $pkg.File) | Out-Null
+                    $null = [io.compression.zipfile]::CreateFromDirectory($TempZipPath, $pkg.File)
                 }
                 catch {throw "Error resizipping $path : $_"}
             }
@@ -1270,7 +1270,7 @@ Function Add-ExcelName {
         }
         else  {
             Write-verbose -Message "Creating Named range '$RangeName' as $($Range.FullAddressAbsolute)."
-            $ws.Names.Add($RangeName, $Range) | Out-Null
+            $null = $ws.Names.Add($RangeName, $Range)
         }
     }
     catch {Write-Warning -Message "Failed adding named range '$RangeName' to worksheet '$($ws.Name)': $_"  }

--- a/Export-Excel.ps1
+++ b/Export-Excel.ps1
@@ -625,7 +625,7 @@
           if it was passed it is a data table don't do foreach on it (slow) put the whole table in and set dates on date columns,
           set things up for the end block, and skip the process block #>
         if ($InputObject -is  [System.Data.DataTable])  {
-            $ws.Cells[$row,$StartColumn].LoadFromDataTable($InputObject, (-not $noHeader) )  | Out-Null
+            $null = $ws.Cells[$row,$StartColumn].LoadFromDataTable($InputObject, (-not $noHeader) )
             foreach ($c in $InputObject.Columns.where({$_.datatype -eq [datetime]})) {
                 Set-ExcelColumn -Worksheet $ws -Column ($c.Ordinal + $StartColumn) -NumberFormat 'Date-Time'
             }

--- a/Export-Excel.ps1
+++ b/Export-Excel.ps1
@@ -635,7 +635,7 @@
             $ColumnIndex         += $InputObject.Columns.Count - 1
             if ($noHeader) {$row += $InputObject.Rows.Count -1 }
             else           {$row += $InputObject.Rows.Count    }
-            [void]$PSBoundParameters.Remove('InputObject')
+            $null = $PSBoundParameters.Remove('InputObject')
             $firstTimeThru = $false
         }
         #endregion

--- a/Install.ps1
+++ b/Install.ps1
@@ -85,7 +85,7 @@ Process {
         }
 
         if (-not (Test-Path $InstallDirectory)) {
-            New-Item -Path $InstallDirectory -ItemType Directory -EA Stop | Out-Null
+            $null = New-Item -Path $InstallDirectory -ItemType Directory -EA Stop
             Write-Verbose "$ModuleName created module folder '$InstallDirectory'"
         }
 

--- a/Join-Worksheet.ps1
+++ b/Join-Worksheet.ps1
@@ -198,7 +198,7 @@
     #We accept a bunch of parameters work to pass on to Export-excel ( Autosize, Autofilter, boldtopRow Freeze ); if we have any of those call export-excel otherwise close the package here.
     $params = @{} + $PSBoundParameters
     'Path', 'Clearsheet', 'NoHeader', 'FromLabel', 'LabelBlocks', 'HideSource',
-    'Title', 'TitleFillPattern', 'TitleBackgroundColor', 'TitleBold', 'TitleSize' | ForEach-Object {[void]$params.Remove($_)}
+    'Title', 'TitleFillPattern', 'TitleBackgroundColor', 'TitleBold', 'TitleSize' | ForEach-Object {$null = $params.Remove($_)}
     if ($params.Keys.Count) {
         if ($Title) { $params.StartRow = 2}
         $params.WorkSheetName = $WorkSheetName

--- a/Send-SqlDataToExcel.ps1
+++ b/Send-SqlDataToExcel.ps1
@@ -130,7 +130,7 @@
         }
         if ($PSBoundParameters.AutoFilter -and ($PSBoundParameters.TableName -or $PSBoundParameters.TableStyle)) {
             Write-Warning "Tables are automatically auto-filtered, -AutoFilter will be ignored"
-            [void]$PSBoundParameters.Remove('AutoFilter')
+            $null = $PSBoundParameters.Remove('AutoFilter')
         }
         #We were either given a session object or a connection string (with, optionally a MSSQLServer parameter)
         #If we got -MSSQLServer, create a SQL connection, if we didn't but we got -Connection create an ODBC connection

--- a/Send-SqlDataToExcel.ps1
+++ b/Send-SqlDataToExcel.ps1
@@ -59,7 +59,7 @@
         C:\> $dbPath = 'C:\users\James\Documents\f1Results.xlsx'
         C:\> $SQL = "SELECT top 25 DriverName, Count(RaceDate) as Races, Count(Win) as Wins, Count(Pole) as Poles, Count(FastestLap) as Fastlaps " +
                      " FROM Results GROUP BY DriverName ORDER BY (count(win)) DESC"
-        C:\> Get-SQL -Session F1 -excel -Connection $dbPath -sql $sql -OutputVariable Table | out-null
+        C:\> $null = Get-SQL -Session F1 -excel -Connection $dbPath -sql $sql -OutputVariable Table
 
         C:\> Send-SQLDataToExcel -DataTable $Table -Path ".\demo3.xlsx" -WorkSheetname Gpwinners -autosize  -TableName winners -TableStyle Light6 -show
 

--- a/SetFormat.ps1
+++ b/SetFormat.ps1
@@ -110,7 +110,7 @@
     )
     process {
         if  ($Range -is [Array])  {
-            [void]$PSBoundParameters.Remove("Range")
+            $null = $PSBoundParameters.Remove("Range")
             $Range | Set-ExcelRange @PSBoundParameters
         }
         else {

--- a/__tests__/InputItemParameter.tests.ps1
+++ b/__tests__/InputItemParameter.tests.ps1
@@ -5,13 +5,13 @@ Describe "Exporting with -Inputobject" {
         #Read race results, and group by race name : export 1 row to get headers, leaving enough rows aboce to put in a link for each race
         $results = ((Get-Process) + (Get-Process -id $PID)) | Select-Object -last  10 -Property Name, cpu, pm, handles, StartTime
         $DataTable = [System.Data.DataTable]::new('Test')
-        [void]$DataTable.Columns.Add('Name')
-        [void]$DataTable.Columns.Add('CPU', [double])
-        [void]$DataTable.Columns.Add('PM',  [Long])
-        [void]$DataTable.Columns.Add('Handles',  [Int])
-        [void]$DataTable.Columns.Add('StartTime', [DateTime])
+        $null = $DataTable.Columns.Add('Name')
+        $null = $DataTable.Columns.Add('CPU', [double])
+        $null = $DataTable.Columns.Add('PM', [Long])
+        $null = $DataTable.Columns.Add('Handles', [Int])
+        $null = $DataTable.Columns.Add('StartTime', [DateTime])
         foreach ($r in $results) {
-            [void]$DataTable.Rows.Add($r.name, $r.CPU, $R.PM, $r.Handles, $r.StartTime)
+            $null = $DataTable.Rows.Add($r.name, $r.CPU, $R.PM, $r.Handles, $r.StartTime)
         }
         export-excel        -Path $path -InputObject $results   -WorksheetName Sheet1 -RangeName "Whole"
         export-excel        -Path $path -InputObject $DataTable -WorksheetName Sheet2 -AutoNameRange


### PR DESCRIPTION
I was seeing that the new version was twice as slow compared to my old one, after some investigation I found that the ` | Out-Null` on `LoadFromDataTable` was changing it's execution time on the line from 0 to as long as the xlsx saving time doubling the total execution time.

I also replaced all the `Out-Null` in the module just in case it cusses slowdown in other places.
@jhoneill never use `Out-Null` it's pure evil https://stackoverflow.com/a/5263780