### PR TITLE
Import-Excel Extended HeaderName functionality

### DIFF
--- a/Examples/Import-ExcelWithHeaderName.ps1
+++ b/Examples/Import-ExcelWithHeaderName.ps1
@@ -1,0 +1,22 @@
+# Create Test File
+$path = "$env:TEMP\Test.xlsx"
+Remove-item -Path $path  -ErrorAction SilentlyContinue
+$processes = Get-Process | Select-Object -First 10
+$Processes | Export-Excel $path
+
+# Import the file as is.
+Import-Excel -Path $path | Format-Table
+# Import the file replacing the name of the 2 first headers and discarding the rest.
+Import-Excel -Path $path -HeaderName 'NewA', 'NewB'
+# Import the file selecting 3 of it's columns by name, renaming 2, changing the order and discarding the rest.
+Import-Excel -Path $path -HeaderName ([Ordered]@{Name = 'Process Name' ; StartTime = 'Start'; Path = 'Path'})
+<# Output Example:
+Process Name         Start               Path
+------------         -----               ----
+ApplicationFrameHost 07/04/2019 11:02:19 C:\WINDOWS\system32\ApplicationFrameHost.exe
+AppVShNotify
+audiodg              08/04/2019 19:21:32
+chrome               08/04/2019 16:49:47 C:\Program Files (x86)\Google\Chrome\Application\chrome.exe
+chrome               08/04/2019 16:49:27 C:\Program Files (x86)\Google\Chrome\Application\chrome.exe
+chrome               08/04/2019 16:49:27 C:\Program Files (x86)\Google\Chrome\Application\chrome.exe
+#>


### PR DESCRIPTION
I was using Import-Excel on a file and found that I don't like the headers names and that I don't need them all, I tried to use `-HeaderName` but it was not doing exactly what I needed. First It depends on the headers position and not name, and also I can't skip columns I don't need.
So I added the option to send HashTable to it (In addition to the existing array option) with the columns you want to get and there new name, this lets you do 3 things:
1. Select only the Columns you want (By name).
2. Reorder them if you need.
3. Rename them if you need.

Example of getting only (Process Name, Start, Path) https://github.com/ili101/ImportExcel/blob/Import-ExcelExtendedHeaderName/Examples/Import-ExcelWithHeaderName.ps1

I don't know if this is the best way to do it, or if the implementation is good, So what do you think? I will like to get your opinions.