### PR TITLE
Add ParameterSet "Now-Table"  and making ParameterSets clearer

### DIFF
--- a/Export-Excel.ps1
+++ b/Export-Excel.ps1
@@ -422,11 +422,9 @@
     [OutputType([OfficeOpenXml.ExcelPackage])]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingPlainTextForPassword", "")]
     Param(
-        [Parameter(Mandatory = $true, ParameterSetName = "Path", Position = 0, ValueFromPipelineByPropertyName)]
-        [Parameter(Mandatory = $true, ParameterSetName = "Path-Table"  , Position = 0, ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory = $true, ParameterSetName = "Path", Position = 0)]
         [String]$Path,
-        [Parameter(Mandatory = $true, ParameterSetName = "Package", ValueFromPipelineByPropertyName)]
-        [Parameter(Mandatory = $true, ParameterSetName = "Package-Table", ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory = $true, ParameterSetName = "Package")]
         [OfficeOpenXml.ExcelPackage]$ExcelPackage,
         [Parameter(ValueFromPipeline = $true)]
         [Alias('TargetData')]
@@ -462,9 +460,6 @@
         [Switch]$FreezeFirstColumn,
         [Switch]$FreezeTopRowFirstColumn,
         [Int[]]$FreezePane,
-        [Parameter(ParameterSetName = 'Path')]
-        [Parameter(ParameterSetName = 'Package')]
-        [Parameter(ParameterSetName = 'Now')]
         [Switch]$AutoFilter,
         [Switch]$BoldTopRow,
         [Switch]$NoHeader,
@@ -479,13 +474,7 @@
                 elseif ($_[0] -notmatch '[a-z]') { throw 'Tablename starts with an invalid character.'  }
                 else { $true }
             })]
-        [Parameter(ParameterSetName = 'Path-Table'    , Mandatory = $true, ValueFromPipelineByPropertyName)]
-        [Parameter(ParameterSetName = 'Package-Table' , Mandatory = $true, ValueFromPipelineByPropertyName)]
-        [Parameter(ParameterSetName = 'Now-Table'     , Mandatory = $true, ValueFromPipelineByPropertyName)]
         [String]$TableName,
-        [Parameter(ParameterSetName = 'Path-Table')]
-        [Parameter(ParameterSetName = 'Package-Table')]
-        [Parameter(ParameterSetName = 'Now-Table')]
         [OfficeOpenXml.Table.TableStyles]$TableStyle,
         [Switch]$Barchart,
         [Switch]$PieChart,
@@ -513,7 +502,6 @@
         [ScriptBlock]$CellStyleSB,
         #If there is already content in the workbook the sheet with the PivotTable will not be active UNLESS Activate is specified
         [switch]$Activate,
-        [Parameter(ParameterSetName = 'Now-Table')]
         [Parameter(ParameterSetName = 'Now')]
         [Switch]$Now,
         [Switch]$ReturnRange,
@@ -533,6 +521,7 @@
         try   {
             $script:Header = $null
             if ($Append -and $ClearSheet) {throw "You can't use -Append AND -ClearSheet."}
+            if ($TableName -or $TableStyle) {$AutoFilter = $false}
             if ($PSBoundParameters.Keys.Count -eq 0 -Or $Now -or (-not $Path -and -not $ExcelPackage) ) {
                 $Path = [System.IO.Path]::GetTempFileName() -replace '\.tmp', '.xlsx'
                 if (-not $PSBoundParameters.ContainsKey("Show")) {$Show = $true}

--- a/Export-Excel.ps1
+++ b/Export-Excel.ps1
@@ -422,11 +422,11 @@
     [OutputType([OfficeOpenXml.ExcelPackage])]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingPlainTextForPassword", "")]
     Param(
-        [Parameter(Mandatory = $true, ParameterSetName = "Path", Position = 0)]
-        [Parameter(Mandatory = $true, ParameterSetName = "Path-Table"  , Position = 0)]
+        [Parameter(Mandatory = $true, ParameterSetName = "Path", Position = 0, ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory = $true, ParameterSetName = "Path-Table"  , Position = 0, ValueFromPipelineByPropertyName)]
         [String]$Path,
-        [Parameter(Mandatory = $true, ParameterSetName = "Package")]
-        [Parameter(Mandatory = $true, ParameterSetName = "Package-Table")]
+        [Parameter(Mandatory = $true, ParameterSetName = "Package", ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory = $true, ParameterSetName = "Package-Table", ValueFromPipelineByPropertyName)]
         [OfficeOpenXml.ExcelPackage]$ExcelPackage,
         [Parameter(ValueFromPipeline = $true)]
         [Alias('TargetData')]
@@ -533,7 +533,7 @@
         try   {
             $script:Header = $null
             if ($Append -and $ClearSheet) {throw "You can't use -Append AND -ClearSheet."}
-            if ($PSCmdlet.ParameterSetName -like 'Now*') {
+            if ($PSBoundParameters.Keys.Count -eq 0 -Or $Now -or (-not $Path -and -not $ExcelPackage) ) {
                 $Path = [System.IO.Path]::GetTempFileName() -replace '\.tmp', '.xlsx'
                 if (-not $PSBoundParameters.ContainsKey("Show")) {$Show = $true}
                 if (-not $PSBoundParameters.ContainsKey("AutoSize")) {$AutoSize = $true}

--- a/Export-Excel.ps1
+++ b/Export-Excel.ps1
@@ -521,7 +521,7 @@
         try   {
             $script:Header = $null
             if ($Append -and $ClearSheet) {throw "You can't use -Append AND -ClearSheet."}
-            if ($TableName -or $TableStyle) {$AutoFilter = $false}
+            if ($TableName -or $PSBoundParameters.ContainsKey($TableStyle)) {$AutoFilter = $false}
             if ($PSBoundParameters.Keys.Count -eq 0 -Or $Now -or (-not $Path -and -not $ExcelPackage) ) {
                 $Path = [System.IO.Path]::GetTempFileName() -replace '\.tmp', '.xlsx'
                 if (-not $PSBoundParameters.ContainsKey("Show")) {$Show = $true}


### PR DESCRIPTION
Before we had the default parameter set "Default" that meant if there where 0 parameters it's "Now" and if there is more it's "Path".
After the update "Default" meant "Now" always except when "Path" is set, making "New" the DefaultParameterSet in practice but not actually the DefaultParameterSetName in code.

That can be a little confusing for example in `Show-Command` if the user will select "Default" but will get different behaviors if he fills -Path or not ("New" behavior if not and "Default" behavior if -Path used)
![2019-04-11_12-35-48](https://user-images.githubusercontent.com/6960531/55951035-f21a4580-5c5e-11e9-89ba-f6575875d6a4.png)

Also parameter set "New-Table" was missing so you can do `Export-Excel -TableName 'Table'` to get -Now behavior but if you explicitly do the same thing `Export-Excel -TableName 'Table' -Now` you will get an error that "Parameter set cannot be resolved"

So I made the "Now" parameter set set the default, this should not change anything but make it more clear if you are using "Now" or not in `Show-Command`
Also I added the missing "New-Table" parameter set.
![2019-04-11_12-26-42](https://user-images.githubusercontent.com/6960531/55951541-30643480-5c60-11e9-9ce8-1bb060b75964.png)

While Writing this I found a problem:
`$DataTable | Export-Excel -TableName 'Table'` is not working, it returns "Supply values for the following parameters: ExcelPackage:" So I workaround it, I reported this to the PowerShell team last year but there is no response yet https://github.com/PowerShell/PowerShell/issues/8516