### PR TITLE
Fixed case on file names, and applied a new rules from script analyzer

### DIFF
--- a/AddConditionalFormatting.ps1
+++ b/AddConditionalFormatting.ps1
@@ -185,7 +185,7 @@
             $Address = "$($Address.Row):$($Address.Row)"
     }
     elseif ($Address -is [OfficeOpenXml.ExcelColumn]) {
-        $Address = [OfficeOpenXml.ExcelAddress]::new(1,$address.ColumnMin,1,$address.ColumnMax).Address -replace '1',''
+        $Address = (New-Object 'OfficeOpenXml.ExcelAddress' @(1, $address.ColumnMin, 1, $address.ColumnMax).Address) -replace '1',''
         if ($Address -notmatch ':') {$Address = "$Address`:$Address"}
     }
     if ( $Address -is [string] -and $Address -match "!") {$Address = $Address -replace '^.*!',''}

--- a/AddDataValidation.ps1
+++ b/AddDataValidation.ps1
@@ -69,9 +69,9 @@
     }
     else {
         #We should accept, a worksheet and a name of a range or a cell address; a table; the address of a table; a named range; a row, a column or .Cells[ ]
-        if      (-not $WorkSheet -and $Range.worksheet) {$WorkSheet = $Range.worksheet} 
+        if      (-not $WorkSheet -and $Range.worksheet) {$WorkSheet = $Range.worksheet}
         if      ($Range.Address)   {$Range = $Range.Address}
-        
+
         if      ($Range -isnot [string] -or -not $WorkSheet) {Write-Warning -Message "You need to provide a worksheet and range of cells." ;return}
        #else we assume Range is a range.
 

--- a/ConvertFromExcelData.ps1
+++ b/ConvertFromExcelData.ps1
@@ -3,7 +3,7 @@ function ConvertFrom-ExcelData {
       .SYNOPSIS
         Reads data from a sheet, and for each row, calls a custom scriptblock with a list of property names and the row of data.
 
-        
+
       .EXAMPLE
         ConvertFrom-ExcelData .\testSQLGen.xlsx {
             param($propertyNames, $record)

--- a/DoTests.ps1
+++ b/DoTests.ps1
@@ -10,7 +10,7 @@ $PSVersionTable.PSVersion
 
 ## Create the zip before the tests run
 ## Otherwise the EPPlus.dll is in use after the Pester run
-$ModuleVersion = (Get-Content -Raw .\ImportExcel.psd1)  | Invoke-Expression | ForEach-Object ModuleVersion
+$ModuleVersion = (Invoke-Command -ScriptBlock ([scriptblock]::Create((Get-Content -Raw .\ImportExcel.psd1)))).moduleVersion
 
 if (!$DontCreateZip) {
     $dest = "ImportExcel-{0}-{1}.zip" -f $ModuleVersion, (Get-Date).ToString("yyyyMMddHHmmss")

--- a/Export-charts.ps1
+++ b/Export-charts.ps1
@@ -1,49 +1,49 @@
 ﻿<#
     .Synopsis
-        Exports the charts in an Excel spreadSheet 
+        Exports the charts in an Excel spreadSheet
     .Example
         Export-Charts .\test.xlsx
         Exports the charts in test.xlsx to JPEG files in the current directory.
 
     .Example
-        Export-Charts -path  .\test,xlsx  -destination [System.Environment+SpecialFolder]::MyDocuments -outputType PNG -passthrough 
-        Exports the charts to PNG files in MyDocuments , and returns file objects representing the newly created files 
+        Export-Charts -path  .\test,xlsx  -destination [System.Environment+SpecialFolder]::MyDocuments -outputType PNG -passthrough
+        Exports the charts to PNG files in MyDocuments , and returns file objects representing the newly created files
 
 #>
 Param (
-    #Path to the Excel file whose chars we will export.  
-    $Path          = "C:\Users\public\Documents\stats.xlsx", 
-    #If specified, output file objects representing the image files  
-    [switch]$Passthru, 
-    #Format to write - JPG by default 
+    #Path to the Excel file whose chars we will export.
+    $Path          = "C:\Users\public\Documents\stats.xlsx",
+    #If specified, output file objects representing the image files
+    [switch]$Passthru,
+    #Format to write - JPG by default
     [ValidateSet("JPG","PNG","GIF")]
-    $OutputType = "JPG", 
-    #Folder to write image files to (defaults to same one as the Excel file is in) 
+    $OutputType = "JPG",
+    #Folder to write image files to (defaults to same one as the Excel file is in)
     $Destination
 )
 
-#if no output folder was specified, set destination to the folder where the Excel file came from 
-if (-not $Destination) {$Destination = Split-Path -Path $Path -Parent } 
+#if no output folder was specified, set destination to the folder where the Excel file came from
+if (-not $Destination) {$Destination = Split-Path -Path $Path -Parent }
 
-#Call up Excel and tell it to open the file. 
-try   { $excelApp      = New-Object -ComObject "Excel.Application" } 
-catch { Write-Warning "Could not start Excel application - which usually means it is not installed."  ; return } 
+#Call up Excel and tell it to open the file.
+try   { $excelApp      = New-Object -ComObject "Excel.Application" }
+catch { Write-Warning "Could not start Excel application - which usually means it is not installed."  ; return }
 
-try   { $excelWorkBook = $excelApp.Workbooks.Open($Path) } 
-catch { Write-Warning -Message "Could not Open $Path."  ; return } 
+try   { $excelWorkBook = $excelApp.Workbooks.Open($Path) }
+catch { Write-Warning -Message "Could not Open $Path."  ; return }
 
-#For each worksheet, for each chart, jump to the chart, create a filename of "WorksheetName_ChartTitle.jpg", and export the file. 
+#For each worksheet, for each chart, jump to the chart, create a filename of "WorksheetName_ChartTitle.jpg", and export the file.
 foreach ($excelWorkSheet in $excelWorkBook.Worksheets) {
-    #note somewhat unusual way of telling excel we want all the charts. 
+    #note somewhat unusual way of telling excel we want all the charts.
     foreach ($excelchart in $excelWorkSheet.ChartObjects([System.Type]::Missing))  {
-        #if you don't go to the chart the image will be zero size ! 
+        #if you don't go to the chart the image will be zero size !
         $excelApp.Goto($excelchart.TopLeftCell,$true)
         $imagePath  = Join-Path -Path $Destination -ChildPath ($excelWorkSheet.Name + "_" + ($excelchart.Chart.ChartTitle.Text -split "\s\d\d:\d\d,")[0] + ".$OutputType")
-        if ( $excelchart.Chart.Export($imagePath, $OutputType, $false) ) {  # Export returs true/false for success/failure 
-            if ($Passthru) {Get-Item -Path $imagePath }                     # when succesful return a file object (-Passthru) or print a verbose message, write warning for any failures 
+        if ( $excelchart.Chart.Export($imagePath, $OutputType, $false) ) {  # Export returs true/false for success/failure
+            if ($Passthru) {Get-Item -Path $imagePath }                     # when succesful return a file object (-Passthru) or print a verbose message, write warning for any failures
             else {Write-Verbose -Message "Exported $imagePath"}
-        } 
-        else     {Write-Warning -Message "Failure exporting $imagePath" } 
+        }
+        else     {Write-Warning -Message "Failure exporting $imagePath" }
     }
 }
 $excelApp.DisplayAlerts = $false

--- a/Get-ExcelSheetInfo.ps1
+++ b/Get-ExcelSheetInfo.ps1
@@ -29,7 +29,7 @@ Function Get-ExcelSheetInfo {
         $stream = New-Object -TypeName System.IO.FileStream -ArgumentList $Path,'Open','Read','ReadWrite'
         $xl = New-Object -TypeName OfficeOpenXml.ExcelPackage -ArgumentList $stream
         $workbook  = $xl.Workbook
-        
+
         if ($workbook -and $workbook.Worksheets) {
             $workbook.Worksheets |
                 Select-Object -Property name,index,hidden,@{

--- a/Get-ExcelWorkbookInfo.ps1
+++ b/Get-ExcelWorkbookInfo.ps1
@@ -1,8 +1,8 @@
 ﻿Function Get-ExcelWorkbookInfo {
-    <# 
-      .SYNOPSIS 
+    <#
+      .SYNOPSIS
         Retrieve information of an Excel workbook.
-      .DESCRIPTION 
+      .DESCRIPTION
         The Get-ExcelWorkbookInfo cmdlet retrieves information (LastModifiedBy, LastPrinted, Created, Modified, ...) fron an Excel workbook. These are the same details that are visible in Windows Explorer when right clicking the Excel file, selecting Properties and check the Details tabpage.
       .PARAMETER Path
         Specifies the path to the Excel file. This parameter is required.
@@ -10,22 +10,22 @@
         Get-ExcelWorkbookInfo .\Test.xlsx
 
         CorePropertiesXml     : #document
-        Title                 : 
-        Subject               : 
+        Title                 :
+        Subject               :
         Author                : Konica Minolta User
-        Comments              : 
-        Keywords              : 
+        Comments              :
+        Keywords              :
         LastModifiedBy        : Bond, James (London) GBR
         LastPrinted           : 2017-01-21T12:36:11Z
         Created               : 17/01/2017 13:51:32
-        Category              : 
-        Status                : 
+        Category              :
+        Status                :
         ExtendedPropertiesXml : #document
         Application           : Microsoft Excel
-        HyperlinkBase         : 
+        HyperlinkBase         :
         AppVersion            : 14.0300
         Company               : Secret Service
-        Manager               : 
+        Manager               :
         Modified              : 10/02/2017 12:45:37
         CustomPropertiesXml   : #document
 
@@ -35,8 +35,8 @@
 
       .LINK
         https://github.com/dfinke/ImportExcel
-    #> 
-    
+    #>
+
     [CmdletBinding()]
     Param (
         [Alias('FullName')]
@@ -52,12 +52,12 @@
             $xl = New-Object -TypeName OfficeOpenXml.ExcelPackage -ArgumentList $stream
             $workbook  = $xl.Workbook
             $workbook.Properties
-            
+
             $stream.Close()
             $stream.Dispose()
             $xl.Dispose()
             $xl = $null
-        }    
+        }
         Catch {
             throw "Failed retrieving Excel workbook information for '$Path': $_"
         }

--- a/Get-HtmlTable.ps1
+++ b/Get-HtmlTable.ps1
@@ -11,7 +11,7 @@ function Get-HtmlTable {
     )
 
     $r = Invoke-WebRequest $url -UseDefaultCredentials: $UseDefaultCredentials
-    
+
     $table = $r.ParsedHtml.getElementsByTagName("table")[$tableIndex]
     $propertyNames=$Header
     $totalRows=@($table.rows).count
@@ -19,7 +19,7 @@ function Get-HtmlTable {
     for ($idx = $FirstDataRow; $idx -lt $totalRows; $idx++) {
 
         $row = $table.rows[$idx]
-        $cells = @($row.cells)        
+        $cells = @($row.cells)
 
         if(!$propertyNames) {
             if($cells[0].tagName -eq 'th') {
@@ -28,7 +28,7 @@ function Get-HtmlTable {
                 $propertyNames =  @(1..($cells.Count + 2) | Foreach-Object { "P$_" })
             }
             continue
-        }        
+        }
 
         $result = [ordered]@{}
 

--- a/GetExcelTable.ps1
+++ b/GetExcelTable.ps1
@@ -96,7 +96,7 @@ function ConvertFrom-ExcelColumnName {
     $sum
 }
 
-ipmo .\ImportExcel.psd1 -Force
+Import-Module .\ImportExcel.psd1 -Force
 
 #Get-ExcelTableName .\testTable.xlsx | Get-ExcelTable .\testTable.xlsx
 Get-ExcelTable .\testTable.xlsx Table3

--- a/Import-Html.ps1
+++ b/Import-Html.ps1
@@ -2,19 +2,19 @@
 function Import-Html {
     [CmdletBinding()]
     param(
-        $url,        
+        $url,
         $index,
         $Header,
         [int]$FirstDataRow=0,
         [Switch]$UseDefaultCredentials
     )
-    
+
     $xlFile = [System.IO.Path]::GetTempFileName() -replace "tmp","xlsx"
-    rm $xlFile -ErrorAction Ignore
+    Remove-Item $xlFile -ErrorAction Ignore
 
     Write-Verbose "Exporting to Excel file $($xlFile)"
 
     $data = Get-HtmlTable -url $url -tableIndex $index -Header $Header -FirstDataRow $FirstDataRow -UseDefaultCredentials: $UseDefaultCredentials
-    
+
     $data | Export-Excel $xlFile -Show -AutoSize
 }

--- a/ImportExcel.psm1
+++ b/ImportExcel.psm1
@@ -48,6 +48,7 @@ if ($PSVersionTable.PSVersion.Major -ge 5) {
     . $PSScriptRoot\Plot.ps1
 
     Function New-Plot {
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification='New-Plot does not change system state')]
         Param()
 
         [PSPlot]::new()
@@ -296,7 +297,7 @@ function Import-Excel {
             .SYNOPSIS
                 Create objects containing the column number and the column name for each of the different header types.
             #>
-
+            [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification="Name would be incorrect, and command is not exported")]
             Param (
                 [Parameter(Mandatory)]
                 [Int[]]$Columns,

--- a/ImportExcel.psm1
+++ b/ImportExcel.psm1
@@ -5,7 +5,7 @@ Add-Type -Path "$($PSScriptRoot)\EPPlus.dll"
 . $PSScriptRoot\Charting.ps1
 . $PSScriptRoot\ColorCompletion.ps1
 . $PSScriptRoot\ConvertExcelToImageFile.ps1
-. $PSScriptRoot\Compare-WorkSheet.ps1
+. $PSScriptRoot\compare-workSheet.ps1
 . $PSScriptRoot\ConvertFromExcelData.ps1
 . $PSScriptRoot\ConvertFromExcelToSQLInsert.ps1
 . $PSScriptRoot\ConvertToExcelXlsx.ps1
@@ -22,8 +22,8 @@ Add-Type -Path "$($PSScriptRoot)\EPPlus.dll"
 . $PSScriptRoot\Import-Html.ps1
 . $PSScriptRoot\InferData.ps1
 . $PSScriptRoot\Invoke-Sum.ps1
-. $PSScriptRoot\Join-WorkSheet.ps1
-. $PSScriptRoot\Merge-Worksheet.ps1
+. $PSScriptRoot\Join-Worksheet.ps1
+. $PSScriptRoot\Merge-worksheet.ps1
 . $PSScriptRoot\New-ConditionalFormattingIconSet.ps1
 . $PSScriptRoot\New-ConditionalText.ps1
 . $PSScriptRoot\New-ExcelChart.ps1
@@ -32,7 +32,7 @@ Add-Type -Path "$($PSScriptRoot)\EPPlus.dll"
 . $PSScriptRoot\Pivot.ps1
 . $PSScriptRoot\PivotTable.ps1
 . $PSScriptRoot\RemoveWorksheet.ps1
-. $PSScriptRoot\Send-SQLDataToExcel.ps1
+. $PSScriptRoot\Send-SqlDataToExcel.ps1
 . $PSScriptRoot\Set-CellStyle.ps1
 . $PSScriptRoot\Set-Column.ps1
 . $PSScriptRoot\Set-Row.ps1
@@ -45,7 +45,7 @@ Add-Type -Path "$($PSScriptRoot)\EPPlus.dll"
 New-Alias -Name Use-ExcelData -Value "ConvertFrom-ExcelData" -Force
 
 if ($PSVersionTable.PSVersion.Major -ge 5) {
-    . $PSScriptRoot\Plot.ps1
+    . $PSScriptRoot\plot.ps1
 
     Function New-Plot {
         [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification='New-Plot does not change system state')]

--- a/Install.ps1
+++ b/Install.ps1
@@ -1,5 +1,5 @@
-<# 
-    .SYNOPSIS   
+<#
+    .SYNOPSIS
         Download the module files from GitHub.
 
     .DESCRIPTION
@@ -90,7 +90,7 @@ Process {
         }
 
         $WebClient = New-Object System.Net.WebClient
-        
+
         $Files | ForEach-Object {
             $WebClient.DownloadFile("$GitPath/$_","$installDirectory\$_")
             Write-Verbose "$ModuleName installed module file '$_'"

--- a/Invoke-Sum.ps1
+++ b/Invoke-Sum.ps1
@@ -18,7 +18,7 @@ function Invoke-Sum {
             $h.$key=[ordered]@{}
         }
 
-        foreach($m in $measure) {        
+        foreach($m in $measure) {
             $value = $item.$m
             if($value -is [string] -or $value -is [System.Enum]) {
                 $value = 1
@@ -27,15 +27,15 @@ function Invoke-Sum {
             $h.$key.$m+=$value
         }
     }
-    
+
     foreach ($entry in $h.GetEnumerator()){
-        
+
         $nh=[ordered]@{Name=$entry.key}
-        
+
         foreach ($item in $entry.value.getenumerator()) {
             $nh.($item.key)=$item.value
-        }        
-        
+        }
+
         [pscustomobject]$nh
     }
 }

--- a/LoadPSD1.ps1
+++ b/LoadPSD1.ps1
@@ -1,3 +1,3 @@
-if((Get-Module -list ImportExcel) -eq $null) {
+if($null -eq (Get-Module -ListAvailable ImportExcel) ) {
     Import-Module $PSScriptRoot\ImportExcel.psd1 -force
 }

--- a/Merge-worksheet.ps1
+++ b/Merge-worksheet.ps1
@@ -316,10 +316,10 @@
 }
 
 Function Merge-MultipleSheets {
-  <#
-    .Synopsis
+   <#
+      .Synopsis
         Merges Worksheets into a single Worksheet with differences marked up.
-    .Description
+      .Description
         The Merge Worksheet command combines two sheets. Merge-MultipleSheets is
         designed to merge more than two. So if asked to merge sheets A,B,C  which
         contain Services, with a Name, Displayname and Start mode, where "Name" is
@@ -353,30 +353,32 @@ Function Merge-MultipleSheets {
         sheet.   However if Sheet B is the reference sheet, A and C will be seen to
         have an item removed; and if B is processed before C, the extra item is
         known when C is processed and so C is considered to be missing that item.
-    .Example
+      .Example
         dir Server*.xlsx | Merge-MulipleSheets   -WorksheetName Services -OutputFile Test2.xlsx -OutputSheetName Services -Show
         Here we are auditing servers and each one has a workbook in the current
         directory which contains a "Services" Worksheet (the result of
         Get-WmiObject -Class win32_service  | Select-Object -Property Name, Displayname, Startmode)
         No key is specified so the key is assumed to be the "Name" column.
         The files are merged and the result is opened on completion.
-    .Example
+      .Example
         dir Serv*.xlsx |  Merge-MulipleSheets  -WorksheetName Software -Key "*" -ExcludeProperty Install* -OutputFile Test2.xlsx -OutputSheetName Software -Show
         The server audit files in the previous example also have "Software" worksheet,
         but no single field on that sheet works as a key. Specifying "*" for the key
         produces a compound key using all non-excluded fields (and the installation
         date and file location are excluded).
-    .Example
+      .Example
         Merge-MulipleSheets -Path hotfixes.xlsx -WorksheetName Serv* -Key hotfixid -OutputFile test2.xlsx -OutputSheetName hotfixes  -HideRowNumbers -Show
         This time all the servers have written their hotfix information to their own
         worksheets in a shared Excel workbook named "Hotfixes.xlsx" (the information was
         obtained by running Get-Hotfix | Sort-Object -Property description,hotfixid  | Select-Object -Property Description,HotfixID)
         This ignores any sheets which are not named "Serv*", and uses the HotfixID as
         the key; in this version the row numbers are hidden.
-  #>
-  [cmdletbinding()]
-  #[Alias("Merge-MulipleSheets")] #There was a spelling error in the first release. This was there to ensure things didn't break but intelisense gave the alias first.
-   param   (
+    #>
+    [cmdletbinding()]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '', Justification="False positives when initializing variable in begin block")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification="MultipleSheet would be incorrect")]
+    #[Alias("Merge-MulipleSheets")] #There was a spelling error in the first release. This was there to ensure things didn't break but intelisense gave the alias first.
+    param   (
         #Paths to the files to be merged. Files are also accepted
         [Parameter(Mandatory=$true,ValueFromPipeline=$true)]
         $Path  ,
@@ -418,9 +420,9 @@ Function Merge-MultipleSheets {
         #If specified, opens the output workbook.
         [Switch]$Show
    )
-   begin   {    $filestoProcess   = @()  }
-   process {    $filestoProcess  += $Path}
-   end     {
+    begin   {    $filestoProcess   = @()  }
+    process {    $filestoProcess  += $Path}
+    end     {
         if     ($filestoProcess.Count -eq 1 -and $WorksheetName -match '\*') {
             Write-Progress -Activity "Merging sheets" -CurrentOperation "Expanding * to names of sheets in $($filestoProcess[0]). "
             $excel = Open-ExcelPackage -Path $filestoProcess
@@ -532,5 +534,5 @@ Function Merge-MultipleSheets {
         if ($Passthru) {$excel}
         else {Close-ExcelPackage -ExcelPackage $excel -Show:$Show}
         Write-Progress -Activity "Merging sheets" -Completed
-   }
+    }
 }

--- a/New-ConditionalFormattingIconSet.ps1
+++ b/New-ConditionalFormattingIconSet.ps1
@@ -27,6 +27,7 @@ function New-ConditionalFormattingIconSet {
         Add-Add-ConditionalFormatting
         New-ConditionalText
     #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',Justification='Does not change system State')]
     param(
         [Parameter(Mandatory=$true)]
         $Range,

--- a/New-ConditionalText.ps1
+++ b/New-ConditionalText.ps1
@@ -42,8 +42,8 @@ function New-ConditionalText {
         Add-Add-ConditionalFormatting
         New-ConditionalFormattingIconSet
     #>
-
     [cmdletbinding()]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',Justification='Does not change system State')]
     param(
         #[Parameter(Mandatory=$true)]
         [Alias("ConditionValue")]

--- a/New-ExcelChart.ps1
+++ b/New-ExcelChart.ps1
@@ -97,6 +97,7 @@
     #>
     [Alias("New-ExcelChart")] #This was the former name. The new name reflects that we are defining a chart, not making one in the workbook.
     [cmdletbinding()]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',Justification='Does not change system State')]
     param(
         $Title = "Chart Title",
         $Header,

--- a/New-PSItem.ps1
+++ b/New-PSItem.ps1
@@ -1,3 +1,5 @@
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Scope='Function', Target='New*', Justification='Does not change system State')]
+param()
 function New-PSItem {
 
     $totalArgs = $args.Count

--- a/PivotTable.ps1
+++ b/PivotTable.ps1
@@ -312,6 +312,7 @@ function New-PivotTableDefinition {
 
         This is a re-work of one of the examples in Export-Excel - instead of writing out the pivot definition hash table it is built by calling New-PivotTableDefinition.
     #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',Justification='Does not change system State')]
     param(
         [Parameter(Mandatory)]
         [Alias("PivtoTableName")]#Previous typo - use alias to avoid breaking scripts

--- a/RemoveWorksheet.ps1
+++ b/RemoveWorksheet.ps1
@@ -15,7 +15,8 @@
         C:\> dir c:\reports\*.xlsx | Remove-WorkSheet
         Removes 'Sheet1' from all the xlsx files in the c:\reports directory
 
-#>
+    #>
+    [cmdletbinding(SupportsShouldProcess=$true)]
     param(
         #    [Parameter(ValueFromPipelineByPropertyName)]
         [Parameter(ValueFromPipelineByPropertyName)]
@@ -34,9 +35,10 @@
 
         if ($pkg) {
             foreach ($wsn in $WorksheetName) {
-                $pkg.Workbook.Worksheets.Delete($wsn)
+                if ($PSCmdlet.ShouldProcess($FullName,"Remove Sheet $wsn")) {
+                    $pkg.Workbook.Worksheets.Delete($wsn)
+                }
             }
-
             Close-ExcelPackage -ExcelPackage $pkg -Show:$Show
         }
     }

--- a/Send-SqlDataToExcel.ps1
+++ b/Send-SqlDataToExcel.ps1
@@ -90,6 +90,8 @@
         Export-Excel
     #>
     [CmdletBinding(DefaultParameterSetName="none")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidGlobalVars', '', Justification="Allowed to use DBSessions Global variable from GETSQL Module")]
+
     param (
         [Parameter(ParameterSetName="SQLConnection",   Mandatory=$true)]
         [Parameter(ParameterSetName="ODBCConnection",  Mandatory=$true)]

--- a/Set-CellStyle.ps1
+++ b/Set-CellStyle.ps1
@@ -1,4 +1,7 @@
-﻿function Set-CellStyle {
+﻿[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Scope='Function', Target='Set*', Justification='Does not change system state')]
+param()
+
+function Set-CellStyle {
     param(
         $WorkSheet,
         $Row,

--- a/Set-Column.ps1
+++ b/Set-Column.ps1
@@ -44,6 +44,8 @@
     [cmdletbinding()]
     [Alias("Set-Column")]
     [OutputType([OfficeOpenXml.ExcelColumn],[String])]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',Justification='Does not change system state')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '', Justification="Variables created for script block which may be passed as a parameter, but not used in the script")]
     Param (
         #If specifying the worksheet by name, the ExcelPackage object which contains the worksheet also needs to be passed.
         [Parameter(ParameterSetName="Package",Mandatory=$true)]
@@ -138,7 +140,7 @@
     process {
         if ($null -eq $workSheet.Dimension) {Write-Warning "Can't format an empty worksheet."; return}
         if ($Column  -eq 0 )  {$Column     = $endColumn    + 1 }
-        $columnName = [OfficeOpenXml.ExcelCellAddress]::new(1,$column).Address -replace "1",""
+        $columnName = (New-Object 'OfficeOpenXml.ExcelCellAddress' @(1, $column)).Address -replace "1",""
         Write-Verbose -Message "Updating Column $columnName"
         #If there is a heading, insert it and use it as the name for a range (if we're creating one)
         if      ($PSBoundParameters.ContainsKey('Heading'))                 {

--- a/Set-Row.ps1
+++ b/Set-Row.ps1
@@ -33,6 +33,8 @@
     [cmdletbinding()]
     [Alias("Set-Row")]
     [OutputType([OfficeOpenXml.ExcelRow],[String])]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',Justification='Does not change system state')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '', Justification="Variables created for script block which may be passed as a parameter, but not used in the script")]
     Param (
         #An Excel package object - e.g. from Export-Excel -PassThru - requires a sheet name.
         [Parameter(ParameterSetName="Package",Mandatory=$true)]
@@ -143,7 +145,7 @@
         #Fill in the data
         if      ($PSBoundParameters.ContainsKey('Value')) {foreach ($column in ($StartColumn..$endColumn)) {
             #We might want the column name in a script block
-            $columnName = [OfficeOpenXml.ExcelCellAddress]::new(1,$column).Address -replace "1",""
+            $columnName = (New-Object -TypeName OfficeOpenXml.ExcelCellAddress @(1,$column)).Address -replace "1",""
             if  ($Value -is [scriptblock] ) {
                 #re-create the script block otherwise variables from this function are out of scope.
                 $cellData = & ([scriptblock]::create( $Value ))
@@ -177,7 +179,7 @@
             if ($PSBoundParameters.ContainsKey($p)) {$params[$p] = $PSBoundParameters[$p]}
         }
         if ($params.Count) {
-            $theRange = [OfficeOpenXml.ExcelAddress]::New($Row, $StartColumn, $Row, $endColumn)
+            $theRange = New-Object -TypeName OfficeOpenXml.ExcelAddress @($Row, $StartColumn, $Row, $endColumn)
             Set-ExcelRange -WorkSheet $Worksheet -Range $theRange @params
         }
         #endregion

--- a/Set-WorkSheetProtection.ps1
+++ b/Set-WorkSheetProtection.ps1
@@ -9,6 +9,7 @@
         Set-WorkSheetProtection -WorkSheet $planSheet -IsProtected -AllowAll -AllowInsertColumns:$false -AllowDeleteColumns:$false -UnLockAddress "A:N"
         Turns on protection for the worksheet in $planSheet, checks all the allow boxes excel Insert and Delete columns and unlocks columns A-N
     #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',Justification='Does not change system state')]
     param (
         #The worksheet where protection is to be applied.
         [Parameter(Mandatory=$true)]

--- a/SetFormat.ps1
+++ b/SetFormat.ps1
@@ -32,6 +32,7 @@
     #>
     [cmdletbinding()]
     [Alias("Set-Format")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',Justification='Does not change system state')]
     Param   (
         #One or more row(s), Column(s) and/or block(s) of cells to format.
         [Parameter(ValueFromPipeline = $true,Position=0)]

--- a/Update-FirstObjectProperties.ps1
+++ b/Update-FirstObjectProperties.ps1
@@ -1,6 +1,11 @@
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Scope='Function', Target='Update*', Justification='Does not change system state')]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Scope='Function', Target='Update*', Justification='Property would be incorrect')]
+
+param()
+
 Function Update-FirstObjectProperties {
-    <# 
-        .SYNOPSIS   
+    <#
+        .SYNOPSIS
             Updates the first object to contain all the properties of the object with the most properties in the array.
 
         .DESCRIPTION
@@ -30,7 +35,7 @@ Function Update-FirstObjectProperties {
             $Array = $Obj1, $Obj2, $Obj3
             $Array | Out-GridView -Title 'Not showing Member3 and Member4'
             $Array | Update-FirstObjectProperties | Out-GridView -Title 'All properties are visible'
-            
+
             Updates the fist object of the array by adding Member3 and Member4.
 
         .EXAMPLE
@@ -79,7 +84,7 @@ Function Update-FirstObjectProperties {
         $Union = @()
         $Input | ForEach-Object {
             If ($Union.Count) {
-                $_ | Get-Member | Where {-not ($Union[0] | Get-Member $_.Name)} | ForEach-Object {
+                $_ | Get-Member | Where-Object {-not ($Union[0] | Get-Member $_.Name)} | ForEach-Object {
                     $Union[0] | Add-Member -MemberType NoteProperty -Name $_.Name -Value $Null
                 }
             }

--- a/__tests__/Compare-WorkSheet.tests.ps1
+++ b/__tests__/Compare-WorkSheet.tests.ps1
@@ -114,7 +114,7 @@ Describe "Compare Worksheet" {
 
     Context "More complex comparison: output check and different worksheet names " {
         BeforeAll {
-            [System.Collections.ArrayList]$s = get-service | Select-Object -first 25 -Property RequiredServices, CanPauseAndContinue, CanShutdown, CanStop, 
+            [System.Collections.ArrayList]$s = get-service | Select-Object -first 25 -Property RequiredServices, CanPauseAndContinue, CanShutdown, CanStop,
             DisplayName, DependentServices, MachineName, ServiceName, ServicesDependedOn, ServiceHandle, Status, ServiceType, StartType  -ExcludeProperty Name
             $s | Export-Excel -Path $env:temp\server1.xlsx  -WorkSheetname Server1
             #$s is a zero based array, excel rows are 1 based and excel has a header row so Excel rows will be 2 + index in $s
@@ -328,7 +328,7 @@ Describe "Merge Multiple sheets" {
             $ws.Cells[12,9 ].Value                                        | Should     be $ws.Cells[12,5].Value
             $ws.Cells[12,10].Value                                        | Should     be $ws.Cells[12,6].Value
         }
-        it "Creared Conditional formatting rules                                                   " {
+        it "Created Conditional formatting rules                                                   " {
             $cf=$ws.ConditionalFormatting
             $cf.Count                                                     | Should     be 17
             $cf[16].Address.Address                                       | Should     be 'B2:B1048576'

--- a/__tests__/Join-Worksheet.tests.ps1
+++ b/__tests__/Join-Worksheet.tests.ps1
@@ -91,9 +91,9 @@ Describe "Join Worksheet part 1" {
 }
     $path = "$env:TEMP\Test.xlsx"
     Remove-item -Path $path -ErrorAction SilentlyContinue
-IF ($PSVersionTable.PSVersion.Major -gt 5) {Write-warning -message "Part 2 Does not run on V6"; return}
+#switched from WMI to CIM objects so test runs on V6
 Describe "Join Worksheet part 2" {
-     Get-WmiObject -Class win32_logicaldisk |
+     Get-CimInstance -ClassName win32_logicaldisk |
         Select-Object -Property DeviceId,VolumeName, Size,Freespace |
             Export-Excel -Path $path -WorkSheetname Volumes -NumberFormat "0,000"
     Get-NetAdapter  |
@@ -122,6 +122,6 @@ Describe "Join Worksheet part 2" {
             $ws.Cells["A$NextRow"].Value                                | Should     be $excel.Workbook.Worksheets[2].Cells["A2"].value
             $ws.Cells["B$NextRow"].Value                                | Should     be $excel.Workbook.Worksheets[2].Cells["B2"].value
         }
-    } 
-} 
+    }
+}
 

--- a/__tests__/Join-Worksheet.tests.ps1
+++ b/__tests__/Join-Worksheet.tests.ps1
@@ -91,12 +91,12 @@ Describe "Join Worksheet part 1" {
 }
     $path = "$env:TEMP\Test.xlsx"
     Remove-item -Path $path -ErrorAction SilentlyContinue
-#switched from WMI to CIM objects so test runs on V6
+#switched to CIM objects so test runs on V6
 Describe "Join Worksheet part 2" {
-     Get-CimInstance -ClassName win32_logicaldisk |
+    Get-CimInstance -ClassName win32_logicaldisk |
         Select-Object -Property DeviceId,VolumeName, Size,Freespace |
             Export-Excel -Path $path -WorkSheetname Volumes -NumberFormat "0,000"
-    Get-NetAdapter  |
+    Get-CimInstance -Namespace root/StandardCimv2 -class MSFT_NetAdapter   |
         Select-Object -Property Name,InterfaceDescription,MacAddress,LinkSpeed |
             Export-Excel -Path $path -WorkSheetname NetAdapters
 

--- a/compare-worksheet.ps1
+++ b/compare-worksheet.ps1
@@ -69,6 +69,8 @@
         Only the unchanged rows are highlighted.
 #>
     [cmdletbinding(DefaultParameterSetName)]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification="Write host used for sub-warning level message to operator which does not form output")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '', Justification="False positives when initializing variable in begin block")]
     Param(
         #First file to compare.
         [parameter(Mandatory=$true,Position=0)]
@@ -219,10 +221,8 @@
     }
     elseif  ($diff -and $FontColor) {Write-Warning -Message "To match rows to set changed cells, you must specify -Key and it must match one of the included properties." }
 
-    #if nothing was found write a message which wont be redirected
+    #if nothing was found write a message which will not be redirected
     if (-not $diff) {Write-Host "Comparison of $Referencefile::$worksheet1 and $Differencefile::$WorkSheet2 returned no results."  }
-
-
 
     if      ($Show)               {
         Start-Process -FilePath $Referencefile

--- a/plot.ps1
+++ b/plot.ps1
@@ -1,6 +1,8 @@
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '', Justification="False positives")]
+param()
 class PSPlot {
     hidden $path
-    hidden $pkg 
+    hidden $pkg
     hidden $ws
     hidden $chart
 
@@ -11,62 +13,62 @@ class PSPlot {
     }
 
     [PSPlot] Plot($yValues) {
-        
+
         $this.NewChart()
-            
+
         $xValues = 0..$yValues.Count
 
         $xCol = 'A'
         $yCol = 'B'
 
-        $this.AddDataToSheet($xCol,$yCol,'x','y',$xValues,$yValues)        
+        $this.AddDataToSheet($xCol,$yCol,'x','y',$xValues,$yValues)
         $this.AddSeries($xCol,$yCol,$yValues)
         $this.SetChartPosition($yCol)
-        
+
         return $this
     }
 
     [PSPlot] Plot($yValues,[string]$options) {
         $this.NewChart()
-            
+
         $xValues = 0..$yValues.Count
 
         $xCol = 'A'
         $yCol = 'B'
 
-        $this.AddDataToSheet($xCol,$yCol,'x','y',$xValues,$yValues)        
+        $this.AddDataToSheet($xCol,$yCol,'x','y',$xValues,$yValues)
         $this.AddSeries($xCol,$yCol,$yValues)
 
-        $this.SetMarkerInfo($options)        
+        $this.SetMarkerInfo($options)
         $this.SetChartPosition($yCol)
 
         return $this
     }
 
     [PSPlot] Plot($xValues,$yValues) {
-        
-        $this.NewChart()        
+
+        $this.NewChart()
 
         $xCol = 'A'
         $yCol = 'B'
 
-        $this.AddDataToSheet($xCol,$yCol,'x','y',$xValues,$yValues)        
+        $this.AddDataToSheet($xCol,$yCol,'x','y',$xValues,$yValues)
         $this.AddSeries($xCol,$yCol,$yValues)
 
         $this.SetChartPosition($yCol)
 
         return $this
     }
-    
+
     [PSPlot] Plot($xValues,$yValues,[string]$options) {
-        $this.NewChart()        
+        $this.NewChart()
 
         $xCol = 'A'
         $yCol = 'B'
 
-        $this.AddDataToSheet($xCol,$yCol,'x','y',$xValues,$yValues)        
+        $this.AddDataToSheet($xCol,$yCol,'x','y',$xValues,$yValues)
         $this.AddSeries($xCol,$yCol,$yValues)
-        
+
         $this.SetMarkerInfo($options)
 
         $this.SetChartPosition($yCol)
@@ -75,19 +77,19 @@ class PSPlot {
     }
 
     [PSPlot] Plot($xValues,$yValues,$x1Values,$y1Values) {
-        
-        $this.NewChart()        
+
+        $this.NewChart()
 
         $xCol = 'A'
         $yCol = 'B'
 
-        $this.AddDataToSheet($xCol,$yCol,'x','y',$xValues,$yValues)        
+        $this.AddDataToSheet($xCol,$yCol,'x','y',$xValues,$yValues)
         $this.AddSeries($xCol,$yCol,$yValues)
 
         $xCol=$this.GetNextColumnName($yCol)
         $yCol=$this.GetNextColumnName($xCol)
 
-        $this.AddDataToSheet($xCol,$yCol,'x1','y1',$x1Values,$y1Values)        
+        $this.AddDataToSheet($xCol,$yCol,'x1','y1',$x1Values,$y1Values)
         $this.AddSeries($xCol,$yCol,$y1Values)
 
         $this.SetChartPosition($yCol)
@@ -96,32 +98,32 @@ class PSPlot {
     }
 
     [PSPlot] Plot($xValues,$yValues,$x1Values,$y1Values,$x2Values,$y2Values) {
-        
-        $this.NewChart()        
+
+        $this.NewChart()
 
         $xCol = 'A'
         $yCol = 'B'
 
-        $this.AddDataToSheet($xCol,$yCol,'x','y',$xValues,$yValues)        
+        $this.AddDataToSheet($xCol,$yCol,'x','y',$xValues,$yValues)
         $this.AddSeries($xCol,$yCol,$yValues)
 
         $xCol=$this.GetNextColumnName($yCol)
         $yCol=$this.GetNextColumnName($xCol)
 
-        $this.AddDataToSheet($xCol,$yCol,'x1','y1',$x1Values,$y1Values)        
+        $this.AddDataToSheet($xCol,$yCol,'x1','y1',$x1Values,$y1Values)
         $this.AddSeries($xCol,$yCol,$y1Values)
 
         $xCol=$this.GetNextColumnName($yCol)
         $yCol=$this.GetNextColumnName($xCol)
 
-        $this.AddDataToSheet($xCol,$yCol,'x2','y2',$x2Values,$y2Values)        
+        $this.AddDataToSheet($xCol,$yCol,'x2','y2',$x2Values,$y2Values)
         $this.AddSeries($xCol,$yCol,$y2Values)
 
         $this.SetChartPosition($yCol)
 
         return $this
     }
-    
+
     [PSPLot] SetChartPosition($yCol) {
         $columnNumber = $this.GetColumnNumber($yCol)+1
         $this.chart.SetPosition(1,0,$columnNumber,0)
@@ -131,29 +133,29 @@ class PSPlot {
 
     AddSeries($xCol,$yCol,$yValues) {
         $yRange = "{0}2:{0}{1}" -f $yCol,($yValues.Count+1)
-        $xRange = "{0}2:{0}{1}" -f $xCol,($yValues.Count+1)                
-        $Series=$this.chart.Series.Add($yRange,$xRange)    
+        $xRange = "{0}2:{0}{1}" -f $xCol,($yValues.Count+1)
+        $Series=$this.chart.Series.Add($yRange,$xRange)
     }
 
     hidden SetMarkerInfo([string]$options) {
         $c=$options.Substring(0,1)
         $m=$options.Substring(1)
-        
+
         $cmap=@{r='red';g='green';b='blue';i='indigo';v='violet';c='cyan'}
         $mmap=@{Ci='Circle';Da='Dash';di='diamond';do='dot';pl='plus';sq='square';tr='triangle'}
-        
+
         $this.chart.Series[0].Marker = $mmap.$m
         $this.chart.Series[0].MarkerColor = $cmap.$c
         $this.chart.Series[0].MarkerLineColor = $cmap.$c
     }
 
     hidden [string]GetNextColumnName($columnName) {
-        return $this.GetColumnName($this.GetColumnNumber($columnName)+1)        
+        return $this.GetColumnName($this.GetColumnNumber($columnName)+1)
     }
 
     hidden [int]GetColumnNumber($columnName) {
         $sum=0
-        
+
         $columnName.ToCharArray() |
             ForEach-Object {
                 $sum*=26
@@ -179,20 +181,20 @@ class PSPlot {
         $count=$yValues.Count
         $this.ws.Cells["$($xColumn)1"].Value=$xHeader
         $this.ws.Cells["$($yColumn)1"].Value=$yHeader
-        
-        for ($idx= 0; $idx-lt $count; $idx++) { 
-            $row=$idx+2                        
+
+        for ($idx= 0; $idx-lt $count; $idx++) {
+            $row=$idx+2
             $this.ws.Cells["$($xColumn)$($row)"].Value=$xValues[$idx]
             $this.ws.Cells["$($yColumn)$($row)"].Value=$yValues[$idx]
         }
     }
 
-    hidden NewChart() {        
+    hidden NewChart() {
         $chartType="XYScatter"
         #$chartType="line"
         $this.chart=$this.ws.Drawings.AddChart("plot", $chartType)
         $this.chart.Title.Text = 'Plot'
-        $this.chart.Legend.Remove()        
+        $this.chart.Legend.Remove()
         $this.SetChartSize(300,300)
     }
 


### PR DESCRIPTION
Very little functional change - remove-worksheet supports -confirm, and I changed 3 or 4 instances of ::new() to new-object because that will work with PS 4  (we don't expressly want to support 4, but at the same time there's no sense in breaking 4 if we don't need to)
I've made some changes to either bring the code into  line with PSScriptAnalyzer 1.18 guidlines or to tell it where it doesn't need to worry. 
Also fixed a test which didn't work in the appveryor environment. 