### PR TITLE
Cross platform test support

### DIFF
--- a/SetFormat.ps1
+++ b/SetFormat.ps1
@@ -230,12 +230,15 @@
                 else {Write-Warning -Message ("Can set the height of a row or a range but not a {0} object" -f ($Range.GetType().name)) }
             }
             if ($Autosize) {
-                if ($Range -is [OfficeOpenXml.ExcelColumn]) {$Range.AutoFit() }
-                elseif ($Range -is [OfficeOpenXml.ExcelRange] ) {
-                    $Range.AutoFitColumns()
-                }
-                else {Write-Warning -Message ("Can autofit a column or a range but not a {0} object" -f ($Range.GetType().name)) }
+                try {
+                    if ($Range -is [OfficeOpenXml.ExcelColumn]) {$Range.AutoFit() }
+                    elseif ($Range -is [OfficeOpenXml.ExcelRange] ) {
+                        $Range.AutoFitColumns()
 
+                    }
+                    else {Write-Warning -Message ("Can autofit a column or a range but not a {0} object" -f ($Range.GetType().name)) }
+                }
+                catch {Write-Warning -Message "Failed autosizing columns of worksheet '$WorksheetName': $_"}
             }
             elseif ($PSBoundParameters.ContainsKey('Width')) {
                 if ($Range -is [OfficeOpenXml.ExcelColumn]) {$Range.Width = $Width}

--- a/__tests__/AddTrendlinesToAChart.tests.ps1
+++ b/__tests__/AddTrendlinesToAChart.tests.ps1
@@ -1,4 +1,7 @@
-﻿Describe "Test adding trendlines to charts" {
+﻿Import-Module $PSScriptRoot\..\ImportExcel.psd1 -Force
+if (-not $env:TEMP) {$env:TEMP = [IO.Path]::GetTempPath() -replace "/$","" }
+$notWindows =  ($PSVersionTable.os -and $PSVersionTable.os -notMatch 'Windows' )
+Describe "Test adding trendlines to charts" {
     BeforeAll {
         $script:data = ConvertFrom-Csv @"
 Region,Item,TotalSold
@@ -21,7 +24,7 @@ South,avocado,73
         Remove-Item $xlfile -ErrorAction SilentlyContinue
     }
 
-    It "Should add a linear trendline" {
+    It "Should add a linear trendline".PadRight(90)  {
 
         $cd = New-ExcelChartDefinition -XRange Region -YRange TotalSold -ChartType ColumnClustered -ChartTrendLine Linear
         $data | Export-Excel $xlfile -ExcelChartDefinition $cd -AutoNameRange
@@ -34,7 +37,7 @@ South,avocado,73
         Close-ExcelPackage $excel
     }
 
-    It "Should add a MovingAvgerage trendline" {
+    It "Should add a MovingAvgerage trendline".PadRight(90)  {
 
         $cd = New-ExcelChartDefinition -XRange Region -YRange TotalSold -ChartType ColumnClustered -ChartTrendLine MovingAvgerage
         $data | Export-Excel $xlfile -ExcelChartDefinition $cd -AutoNameRange

--- a/__tests__/Compare-WorkSheet.tests.ps1
+++ b/__tests__/Compare-WorkSheet.tests.ps1
@@ -1,4 +1,6 @@
 ﻿#Requires -Modules Pester
+if ($PSVersionTable.os -and $PSVersionTable.os -notMatch 'Windows' ) {return}   #Currently this test outputs windows services so only run on Windows.
+if (-not $env:TEMP) {$env:TEMP = [IO.Path]::GetTempPath() }
 Import-Module $PSScriptRoot\..\ImportExcel.psd1 -Force
 if ($PSVersionTable.PSVersion.Major -gt 5) { Write-Warning "Can't test grid view on V6 and later" }
 else                                       {Add-Type -AssemblyName System.Windows.Forms }
@@ -19,7 +21,7 @@ Describe "Compare Worksheet" {
             $s.RemoveAt(5)
             $s | Export-Excel -Path $env:temp\server2.xlsx
             #Assume default worksheet name, (sheet1) and column header for key ("name")
-            $comp = compare-WorkSheet "$env:temp\Server1.xlsx" "$env:temp\Server2.xlsx" | Sort-Object -Property _row, _file
+            $comp = compare-WorkSheet "$env:temp\server1.xlsx" "$env:temp\server2.xlsx" | Sort-Object -Property _row, _file
         }
         it "Found the right number of differences                                                  " {
             $comp                                                         | should not beNullOrEmpty
@@ -55,13 +57,13 @@ Describe "Compare Worksheet" {
                 $ModulePath = (Get-Command -Name 'Compare-WorkSheet').Module.Path
                 $PowerShellExec = if ($PSEdition -eq 'Core') {'pwsh.exe'} else {'powershell.exe'}
                 $PowerShellPath = Join-Path -Path $PSHOME -ChildPath $PowerShellExec
-                . $PowerShellPath -Command ("Import-Module $ModulePath; " + '$null = Compare-WorkSheet "$env:temp\Server1.xlsx" "$env:temp\Server2.xlsx" -BackgroundColor ([System.Drawing.Color]::LightGreen) -GridView; Start-Sleep -sec 5')
+                . $PowerShellPath -Command ("Import-Module $ModulePath; " + '$null = Compare-WorkSheet "$env:temp\server1.xlsx" "$env:temp\server2.xlsx" -BackgroundColor ([System.Drawing.Color]::LightGreen) -GridView; Start-Sleep -sec 5')
             }
             else {
-                $null = Compare-WorkSheet "$env:temp\Server1.xlsx" "$env:temp\Server2.xlsx" -BackgroundColor ([System.Drawing.Color]::LightGreen) -GridView:$useGrid
+                $null = Compare-WorkSheet "$env:temp\server1.xlsx" "$env:temp\server2.xlsx" -BackgroundColor ([System.Drawing.Color]::LightGreen) -GridView:$useGrid
             }
-            $xl1  = Open-ExcelPackage -Path "$env:temp\Server1.xlsx"
-            $xl2  = Open-ExcelPackage -Path "$env:temp\Server2.xlsx"
+            $xl1  = Open-ExcelPackage -Path "$env:temp\server1.xlsx"
+            $xl2  = Open-ExcelPackage -Path "$env:temp\server2.xlsx"
             $s1Sheet = $xl1.Workbook.Worksheets[1]
             $s2Sheet = $xl2.Workbook.Worksheets[1]
         }
@@ -85,9 +87,9 @@ Describe "Compare Worksheet" {
 
     Context "Setting the forgound to highlight changed properties" {
         BeforeAll {
-            $null = compare-WorkSheet "$env:temp\Server1.xlsx" "$env:temp\Server2.xlsx" -AllDataBackgroundColor([System.Drawing.Color]::white) -BackgroundColor ([System.Drawing.Color]::LightGreen)  -FontColor ([System.Drawing.Color]::DarkRed)
-            $xl1  = Open-ExcelPackage -Path "$env:temp\Server1.xlsx"
-            $xl2  = Open-ExcelPackage -Path "$env:temp\Server2.xlsx"
+            $null = compare-WorkSheet "$env:temp\server1.xlsx" "$env:temp\server2.xlsx" -AllDataBackgroundColor([System.Drawing.Color]::white) -BackgroundColor ([System.Drawing.Color]::LightGreen)  -FontColor ([System.Drawing.Color]::DarkRed)
+            $xl1  = Open-ExcelPackage -Path "$env:temp\server1.xlsx"
+            $xl2  = Open-ExcelPackage -Path "$env:temp\server2.xlsx"
             $s1Sheet = $xl1.Workbook.Worksheets[1]
             $s2Sheet = $xl2.Workbook.Worksheets[1]
         }
@@ -130,9 +132,9 @@ Describe "Compare Worksheet" {
 
             $s | Select-Object -Property ServiceName, DisplayName, StartType, ServiceType | Export-Excel -Path $env:temp\server2.xlsx -WorkSheetname server2
             #Assume default worksheet name, (sheet1) and column header for key ("name")
-            $comp = compare-WorkSheet "$env:temp\Server1.xlsx" "$env:temp\Server2.xlsx" -WorkSheetName Server1,Server2 -Key ServiceName -Property DisplayName,StartType -AllDataBackgroundColor ([System.Drawing.Color]::AliceBlue) -BackgroundColor ([System.Drawing.Color]::White) -FontColor ([System.Drawing.Color]::Red)   | Sort-Object _row,_file
-            $xl1  = Open-ExcelPackage -Path "$env:temp\Server1.xlsx"
-            $xl2  = Open-ExcelPackage -Path "$env:temp\Server2.xlsx"
+            $comp = compare-WorkSheet "$env:temp\server1.xlsx" "$env:temp\server2.xlsx" -WorkSheetName Server1,Server2 -Key ServiceName -Property DisplayName,StartType -AllDataBackgroundColor ([System.Drawing.Color]::AliceBlue) -BackgroundColor ([System.Drawing.Color]::White) -FontColor ([System.Drawing.Color]::Red)   | Sort-Object _row,_file
+            $xl1  = Open-ExcelPackage -Path "$env:temp\server1.xlsx"
+            $xl2  = Open-ExcelPackage -Path "$env:temp\server2.xlsx"
             $s1Sheet = $xl1.Workbook.Worksheets["server1"]
             $s2Sheet = $xl2.Workbook.Worksheets["server2"]
         }
@@ -188,7 +190,7 @@ Describe "Compare Worksheet" {
 Describe "Merge Worksheet" {
     Context "Merge with 3 properties" {
         BeforeAll {
-            Remove-Item -Path  "$env:temp\server*.xlsx" , "$env:temp\Combined*.xlsx" -ErrorAction SilentlyContinue
+            Remove-Item -Path  "$env:temp\server*.xlsx" , "$env:temp\combined*.xlsx" -ErrorAction SilentlyContinue
             [System.Collections.ArrayList]$s = get-service | Select-Object -first 25 -Property *
 
             $s | Export-Excel -Path $env:temp\server1.xlsx
@@ -205,7 +207,7 @@ Describe "Merge Worksheet" {
 
             $s | Export-Excel -Path $env:temp\server2.xlsx
             #Assume default worksheet name, (sheet1) and column header for key ("name")
-            Merge-Worksheet -Referencefile "$env:temp\server1.xlsx" -Differencefile  "$env:temp\Server2.xlsx" -OutputFile  "$env:temp\combined1.xlsx"  -Property name,displayname,startType -Key name
+            Merge-Worksheet -Referencefile "$env:temp\server1.xlsx" -Differencefile  "$env:temp\server2.xlsx" -OutputFile  "$env:temp\combined1.xlsx"  -Property name,displayname,startType -Key name
             $excel = Open-ExcelPackage -Path "$env:temp\combined1.xlsx"
             $ws    = $excel.Workbook.Worksheets["sheet1"]
         }
@@ -247,14 +249,14 @@ Describe "Merge Worksheet" {
     }
     Context "Wider data set"    {
         it "Coped with columns beyond Z in the Output sheet                                        " {
-            { Merge-Worksheet -Referencefile "$env:temp\server1.xlsx" -Differencefile  "$env:temp\Server2.xlsx" -OutputFile  "$env:temp\combined2.xlsx"  }           | Should not throw
+            { Merge-Worksheet -Referencefile "$env:temp\server1.xlsx" -Differencefile  "$env:temp\server2.xlsx" -OutputFile  "$env:temp\combined2.xlsx"  }           | Should not throw
         }
     }
 }
 Describe "Merge Multiple sheets" {
     Context "Merge 3 sheets with 3 properties" {
         BeforeAll {
-            Remove-Item -Path  "$env:temp\server*.xlsx" , "$env:temp\Combined*.xlsx" -ErrorAction SilentlyContinue
+            Remove-Item -Path  "$env:temp\server*.xlsx" , "$env:temp\combined*.xlsx" -ErrorAction SilentlyContinue
             [System.Collections.ArrayList]$s = get-service | Select-Object -first 25 -Property Name,DisplayName,StartType
             $s | Export-Excel -Path $env:temp\server1.xlsx
 
@@ -281,7 +283,7 @@ Describe "Merge Multiple sheets" {
 
             $s | Export-Excel -Path $env:temp\server3.xlsx
 
-            Merge-MultipleSheets -Path "$env:temp\server1.xlsx", "$env:temp\Server2.xlsx","$env:temp\Server3.xlsx" -OutputFile "$env:temp\combined3.xlsx"  -Property name,displayname,startType -Key name
+            Merge-MultipleSheets -Path "$env:temp\server1.xlsx", "$env:temp\server2.xlsx","$env:temp\server3.xlsx" -OutputFile "$env:temp\combined3.xlsx"  -Property name,displayname,startType -Key name
             $excel = Open-ExcelPackage -Path "$env:temp\combined3.xlsx"
             $ws    = $excel.Workbook.Worksheets["sheet1"]
 
@@ -295,10 +297,10 @@ Describe "Merge Multiple sheets" {
             $ws.Cells[ 1,6 ].Value                                        | Should     be "Server2 StartType"
             $ws.Column(7).hidden                                          | Should     be $true
             $ws.Cells[ 1,8].Value                                         | Should     be "Server2 Row"
-            $ws.Cells[ 1,9 ].Value                                        | Should     be "Server3 DisplayName"
-            $ws.Cells[ 1,10].Value                                        | Should     be "Server3 StartType"
+            $ws.Cells[ 1,9 ].Value                                        | Should     be "server3 DisplayName"
+            $ws.Cells[ 1,10].Value                                        | Should     be "server3 StartType"
             $ws.Column(11).hidden                                         | Should     be $true
-            $ws.Cells[ 1,12].Value                                        | Should     be "Server3 Row"
+            $ws.Cells[ 1,12].Value                                        | Should     be "server3 Row"
         }
         it "Joined the three sheets correctly                                                      " {
             $ws.Cells[ 2,3 ].Value                                        | Should     be $ws.Cells[ 2,5 ].Value

--- a/__tests__/ConvertFromExcelToSQLInsert.tests.ps1
+++ b/__tests__/ConvertFromExcelToSQLInsert.tests.ps1
@@ -1,5 +1,5 @@
 ﻿Import-Module $PSScriptRoot\..\ImportExcel.psd1 -Force
-
+if (-not $env:TEMP) {$env:TEMP = [IO.Path]::GetTempPath() -replace "/$","" }
 $xlFile = "$env:TEMP\testSQL.xlsx"
 
 Describe "ConvertFrom-ExcelToSQLInsert" {
@@ -16,7 +16,7 @@ Describe "ConvertFrom-ExcelToSQLInsert" {
         Remove-Item $xlFile -Recurse -Force -ErrorAction Ignore
     }
 
-    It "Should be empty double single quotes" {
+    It "Should be empty double single quotes".PadRight(90)  {
         $expected="INSERT INTO Sheet1 ('Name', 'Age') Values('John', '');"
 
         $actual = ConvertFrom-ExcelToSQLInsert -Path $xlFile Sheet1
@@ -24,7 +24,7 @@ Describe "ConvertFrom-ExcelToSQLInsert" {
         $actual | should be $expected
     }
 
-     It "Should have NULL" {
+     It "Should have NULL".PadRight(90)  {
         $expected="INSERT INTO Sheet1 ('Name', 'Age') Values('John', NULL);"
 
         $actual = ConvertFrom-ExcelToSQLInsert -Path $xlFile Sheet1 -ConvertEmptyStringsToNull

--- a/__tests__/Copy-ExcelWorksheet.Tests.ps1
+++ b/__tests__/Copy-ExcelWorksheet.Tests.ps1
@@ -1,3 +1,6 @@
+if ($PSVersionTable.os -and $PSVersionTable.os -notMatch 'Windows' ) {return}   #Currently this test outputs windows services so only run on Windows.
+if (-not $env:TEMP) {$env:TEMP = [IO.Path]::GetTempPath() -replace "/$","" }
+
 $path1 = "$env:TEMP\Test1.xlsx"
 $path2 = "$env:TEMP\Test2.xlsx"
 Remove-item -Path $path1, $path2  -ErrorAction SilentlyContinue
@@ -91,8 +94,8 @@ Describe "Copy-Worksheet" {
             $xlfile = "$env:TEMP\reports.xlsx"
             $xlfileArchive = "$env:TEMP\reportsArchive.xlsx"
 
-            rm $xlfile -ErrorAction SilentlyContinue
-            rm $xlfileArchive -ErrorAction SilentlyContinue
+            Remove-Item $xlfile -ErrorAction SilentlyContinue
+            Remove-Item $xlfileArchive -ErrorAction SilentlyContinue
 
             $sheets = echo 1.1.2019 1.2.2019 1.3.2019 1.4.2019 1.5.2019
 
@@ -119,8 +122,8 @@ Describe "Copy-Worksheet" {
             $xlfile = "$env:TEMP\reports.xlsx"
             $xlfileArchive = "$env:TEMP\reportsArchive.xlsx"
 
-            rm $xlfile -ErrorAction SilentlyContinue
-            rm $xlfileArchive -ErrorAction SilentlyContinue
+            Remove-Item $xlfile -ErrorAction SilentlyContinue
+            Remove-Item $xlfileArchive -ErrorAction SilentlyContinue
 
             $sheets = echo 1.1.2019 1.2.2019 1.3.2019 1.4.2019 1.5.2019
 

--- a/__tests__/ExtraLongCmd.tests.ps1
+++ b/__tests__/ExtraLongCmd.tests.ps1
@@ -1,6 +1,7 @@
+if (-not $env:TEMP) {$env:TEMP = [IO.Path]::GetTempPath() -replace "/$","" }
 
 
-$path = "$Env:TEMP\test.xlsx"
+$path = Join-Path $Env:TEMP "test.xlsx"
 remove-item -path $path -ErrorAction SilentlyContinue
 ConvertFrom-Csv    @"
 Product, City, Gross, Net

--- a/__tests__/First10Races.tests.ps1
+++ b/__tests__/First10Races.tests.ps1
@@ -1,9 +1,11 @@
-﻿$scriptPath = Split-Path -Path $MyInvocation.MyCommand.path -Parent
+﻿if (-not $env:TEMP) {$env:TEMP = [IO.Path]::GetTempPath() -replace "/$","" }
+
+$scriptPath = Split-Path -Path $MyInvocation.MyCommand.path -Parent
 $dataPath = Join-Path  -Path $scriptPath -ChildPath "First10Races.csv"
 
 Describe "Creating small named ranges with hyperlinks" {
     BeforeAll {
-        $path = "$env:TEMP\Results.xlsx"
+        $path = Join-Path $Env:TEMP "results.xlsx"
         Remove-Item -Path $path -ErrorAction SilentlyContinue
         #Read race results, and group by race name : export 1 row to get headers, leaving enough rows aboce to put in a link for each race
         $results = Import-Csv -Path $dataPath |

--- a/__tests__/FunctionAlias.tests.ps1
+++ b/__tests__/FunctionAlias.tests.ps1
@@ -5,15 +5,15 @@ Import-Module $PSScriptRoot\..\ImportExcel.psd1 -Force
 
 Describe "Check if Function aliases exist" {
 
-    It "Set-Column should exist" {
+    It "Set-Column should exist".PadRight(90) {
         ${Alias:Set-Column} | Should Not BeNullOrEmpty
     }
 
-    It "Set-Row should exist" {
+    It "Set-Row should exist".PadRight(90) {
           ${Alias:Set-Row} | Should Not BeNullOrEmpty
     }
 
-    It "Set-Format should exist" {
+    It "Set-Format should exist".PadRight(90) {
           ${Alias:Set-Format} | Should Not BeNullOrEmpty
     }
 
@@ -21,7 +21,7 @@ Describe "Check if Function aliases exist" {
         Get-Command Merge-MulipleSheets | Should Not Be $null
     }
 #>
-    It "New-ExcelChart should exist" {
+    It "New-ExcelChart should exist".PadRight(90) {
           ${Alias:New-ExcelChart} | Should Not BeNullOrEmpty
     }
 

--- a/__tests__/ImportExcelFileList.tests.ps1
+++ b/__tests__/ImportExcelFileList.tests.ps1
@@ -1,5 +1,5 @@
 Describe "ImportExcel File List" {
-    It "All files should exist" {
+    It "All files should exist".PadRight(90) {
         $fileList = Get-Content "$PSScriptRoot\..\filelist.txt"
 
         foreach ($file in $fileList) {

--- a/__tests__/ImportExcelTests/Simple.tests.ps1
+++ b/__tests__/ImportExcelTests/Simple.tests.ps1
@@ -8,20 +8,20 @@ Describe "Tests" {
         }
     }
 
-    It "Should have two items" {
+    It "Should have two items".PadRight(90) {
         $data.count | Should be 2
     }
 
-    It "Should have items a and b" {
+    It "Should have items a and b".PadRight(90) {
         $data[0].p1 | Should be "a"
         $data[1].p1 | Should be "b"
     }
 
-    It "Should read fast < 2100 milliseconds" {
+    It "Should read fast < 2100 milliseconds".PadRight(90) {
         $timer.TotalMilliseconds | should BeLessThan 2100
     }
 
-    It "Should read larger xlsx, 4k rows 1 col < 3000 milliseconds" {
+    It "Should read larger xlsx, 4k rows 1 col < 3000 milliseconds".PadRight(90) {
         $timer = Measure-Command {
             $null = Import-Excel $PSScriptRoot\LargerFile.xlsx
         }
@@ -29,7 +29,7 @@ Describe "Tests" {
         $timer.TotalMilliseconds | should BeLessThan 3000
     }
 
-    It "Should be able to open, read and close as seperate actions" {
+    It "Should be able to open, read and close as seperate actions".PadRight(90) {
         $timer = Measure-Command {
             $excel = Open-ExcelPackage $PSScriptRoot\Simple.xlsx
             $data = Import-Excel -ExcelPackage $excel

--- a/__tests__/InputItemParameter.tests.ps1
+++ b/__tests__/InputItemParameter.tests.ps1
@@ -1,6 +1,8 @@
+if (-not $env:TEMP) {$env:TEMP = [IO.Path]::GetTempPath() -replace "/$","" }
+
 Describe "Exporting with -Inputobject" {
     BeforeAll {
-        $path = "$env:TEMP\Results.xlsx"
+        $path = Join-Path $Env:TEMP "results.xlsx"
         Remove-Item -Path $path -ErrorAction SilentlyContinue
         #Read race results, and group by race name : export 1 row to get headers, leaving enough rows aboce to put in a link for each race
         $results = ((Get-Process) + (Get-Process -id $PID)) | Select-Object -last  10 -Property Name, cpu, pm, handles, StartTime

--- a/__tests__/Join-Worksheet.tests.ps1
+++ b/__tests__/Join-Worksheet.tests.ps1
@@ -1,4 +1,7 @@
-﻿$data1 = ConvertFrom-Csv -InputObject @"
+﻿if (-not $env:TEMP) {$env:TEMP = [IO.Path]::GetTempPath() -replace "/$","" }
+$notWindows =  ($PSVersionTable.os -and $PSVersionTable.os -notMatch 'Windows' )
+
+$data1 = ConvertFrom-Csv -InputObject @"
 ID,Product,Quantity,Price,Total
 12001,Nails,37,3.99,147.63
 12002,Hammer,5,12.10,60.5
@@ -24,7 +27,7 @@ ID,Product,Quantity,Price,Total
 
 Describe "Join Worksheet part 1" {
     BeforeAll {
-        $path = "$Env:TEMP\test.xlsx"
+        $path = Join-Path $Env:TEMP "test.xlsx"
         Remove-Item -Path $path -ErrorAction SilentlyContinue
         $data1 | Export-Excel -Path $path -WorkSheetname Oxford
         $data2 | Export-Excel -Path $path -WorkSheetname Abingdon
@@ -89,10 +92,11 @@ Describe "Join Worksheet part 1" {
         }
     }
 }
-    $path = "$env:TEMP\Test.xlsx"
+    $path = Join-Path $Env:TEMP "Test.xlsx"
     Remove-item -Path $path -ErrorAction SilentlyContinue
 #switched to CIM objects so test runs on V6
 Describe "Join Worksheet part 2" {
+    if ($notWindows) {Write-warning -message "Test only runs on Windows" ; return}
     Get-CimInstance -ClassName win32_logicaldisk |
         Select-Object -Property DeviceId,VolumeName, Size,Freespace |
             Export-Excel -Path $path -WorkSheetname Volumes -NumberFormat "0,000"

--- a/__tests__/PasswordProtection.tests.ps1
+++ b/__tests__/PasswordProtection.tests.ps1
@@ -1,9 +1,10 @@
-﻿if ($PSVersionTable.PSVersion.Major -GT 5) {
-     Write-Warning "Can't test passwords on V6 and later"
-     return
-}
+﻿
 
 Describe "Password Support" {
+    if ($PSVersionTable.PSVersion.Major -GT 5) {
+        Write-Warning "Can't test passwords on V6 and later"
+        return
+    }
     Context "Password protected sheet" {
         BeforeAll  {
             $password = "YouMustRememberThis"

--- a/__tests__/Path.tests.ps1
+++ b/__tests__/Path.tests.ps1
@@ -1,38 +1,38 @@
 ﻿Describe "Test reading relative paths" {
     BeforeAll {
         $script:xlfileName = "TestR.xlsx"
-        @{data = 1 } | Export-Excel "$pwd\TestR.xlsx"
+        @{data = 1 } | Export-Excel (Join-Path $PWD  "TestR.xlsx")
     }
 
     AfterAll {
-        Remove-Item "$pwd\$($script:xlfileName)"
+        Remove-Item (Join-Path $PWD  "$($script:xlfileName)")
     }
 
-    It "Should read local file" {
+    It "Should read local file".PadRight(90) {
         $actual = Import-Excel -Path ".\$($script:xlfileName)"
         $actual | Should Not Be $null
         $actual.Count | Should Be 1
     }
 
-    It "Should read with pwd" {
-        $actual = Import-Excel -Path "$pwd\$($script:xlfileName)"
+    It "Should read with pwd".PadRight(90){
+        $actual = Import-Excel -Path (Join-Path $PWD  "$($script:xlfileName)")
         $actual | Should Not Be $null
     }
 
-    It "Should read with just a file name and resolve to cwd" {
+    It "Should read with just a file name and resolve to cwd".PadRight(90){
         $actual = Import-Excel -Path "$($script:xlfileName)"
         $actual | Should Not Be $null
     }
 
-    It "Should fail for not found" {
+    It "Should fail for not found".PadRight(90){
         { Import-Excel -Path "ExcelFileDoesNotExist.xlsx" } | Should Throw "'ExcelFileDoesNotExist.xlsx' file not found"
     }
 
-    It "Should fail for xls extension" {
+    It "Should fail for xls extension".PadRight(90){
         { Import-Excel -Path "ExcelFileDoesNotExist.xls" } | Should Throw "Import-Excel does not support reading this extension type .xls"
     }
 
-    It "Should fail for xlsxs extension" {
+    It "Should fail for xlsxs extension".PadRight(90){
         { Import-Excel -Path "ExcelFileDoesNotExist.xlsxs" } | Should Throw "Import-Excel does not support reading this extension type .xlsxs"
     }
 }

--- a/__tests__/ProtectWorksheet.tests.ps1
+++ b/__tests__/ProtectWorksheet.tests.ps1
@@ -1,4 +1,6 @@
-$path = "$Env:TEMP\test.xlsx"
+if (-not $env:TEMP) {$env:TEMP = [IO.Path]::GetTempPath() -replace "/$","" }
+
+$path = Join-Path $Env:TEMP "test.xlsx"
 Remove-Item -path $path -ErrorAction SilentlyContinue
 $excel = ConvertFrom-Csv    @"
 Product, City, Gross, Net

--- a/__tests__/RangePassing.ps1
+++ b/__tests__/RangePassing.ps1
@@ -1,5 +1,10 @@
-$path = "$env:temp\test.xlsx"
+
+if (-not $env:TEMP) {$env:TEMP = [IO.Path]::GetTempPath() -replace "/$","" }
+$notWindows =  ($PSVersionTable.os -and $PSVersionTable.os -notMatch 'Windows' )
+
+$path = Join-Path $Env:TEMP "test.xlsx"
 describe "Consistent passing of ranges." {
+    if ($notWindows) {Write-warning -message "Test uses get-service so only works on Windows" ; return}
     Context "Conditional Formatting"  {
         Remove-Item -path $path  -ErrorAction SilentlyContinue
         $excel = Get-Service | Export-Excel -Path $path -WorksheetName Services -PassThru -AutoSize -DisplayPropertySet -AutoNameRange -Title "Services on $Env:COMPUTERNAME"

--- a/__tests__/Remove-WorkSheet.tests.ps1
+++ b/__tests__/Remove-WorkSheet.tests.ps1
@@ -1,5 +1,6 @@
 ﻿#Requires -Modules Pester
 Import-Module $PSScriptRoot\..\ImportExcel.psd1 -Force
+if (-not $env:TEMP) {$env:TEMP = [IO.Path]::GetTempPath() -replace "/$","" }
 
 Describe "Remove Worksheet" {
     Context "Remove a worksheet output" {
@@ -10,7 +11,7 @@ Name,Age
 Jane,10
 John,20
 "@
-            $xlFile1 = "$env:TEMP\RemoveWorsheet1.xlsx"
+            $xlFile1 = Join-Path $Env:TEMP "removeWorsheet1.xlsx"
             Remove-Item $xlFile1 -ErrorAction SilentlyContinue
 
             $data | Export-Excel -Path $xlFile1 -WorksheetName Target1
@@ -18,7 +19,7 @@ John,20
             $data | Export-Excel -Path $xlFile1 -WorksheetName Target3
             $data | Export-Excel -Path $xlFile1 -WorksheetName Sheet1
 
-            $xlFile2 = "$env:TEMP\RemoveWorsheet2.xlsx"
+            $xlFile2 = Join-Path $Env:TEMP "removeWorsheet2.xlsx"
             Remove-Item $xlFile2 -ErrorAction SilentlyContinue
 
             $data | Export-Excel -Path $xlFile2 -WorksheetName Target1
@@ -27,11 +28,11 @@ John,20
             $data | Export-Excel -Path $xlFile2 -WorksheetName Sheet1
         }
 
-        it "Should throw about the Path" {
+        it "Should throw about the Path".PadRight(87)  {
             {Remove-WorkSheet} | Should throw 'Remove-WorkSheet requires the and Excel file'
         }
 
-        it "Should delete Target2" {
+        it "Should delete Target2".PadRight(87)  {
             Remove-WorkSheet -Path $xlFile1 -WorksheetName Target2
 
             $actual = Get-ExcelSheetInfo -Path $xlFile1
@@ -42,7 +43,7 @@ John,20
             $actual[2].Name | Should Be "Sheet1"
         }
 
-        it "Should delete Sheet1" {
+        it "Should delete Sheet1".PadRight(87)  {
             Remove-WorkSheet -Path $xlFile1
 
             $actual = Get-ExcelSheetInfo -Path $xlFile1
@@ -53,7 +54,7 @@ John,20
             $actual[2].Name | Should Be "Target3"
         }
 
-        it "Should delete multiple sheets" {
+        it "Should delete multiple sheets".PadRight(87)  {
             Remove-WorkSheet -Path $xlFile1 -WorksheetName Target1, Sheet1
 
             $actual = Get-ExcelSheetInfo -Path $xlFile1
@@ -63,9 +64,9 @@ John,20
             $actual[1].Name | Should Be "Target3"
         }
 
-        it "Should delete sheet from multiple workbooks" {
+        it "Should delete sheet from multiple workbooks".PadRight(87)  {
 
-            Get-ChildItem "$env:TEMP\RemoveWorsheet*.xlsx" | Remove-WorkSheet
+            Get-ChildItem (Join-Path $Env:TEMP "removeWorsheet*.xlsx") | Remove-WorkSheet
 
             $actual = Get-ExcelSheetInfo -Path $xlFile1
 

--- a/__tests__/Set-Row_Set-Column-SetFormat.tests.ps1
+++ b/__tests__/Set-Row_Set-Column-SetFormat.tests.ps1
@@ -1,5 +1,6 @@
-﻿
-$path = "$Env:TEMP\test.xlsx"
+﻿Import-Module $PSScriptRoot\..\ImportExcel.psd1 -Force
+if (-not $env:TEMP) {$env:TEMP = [IO.Path]::GetTempPath() -replace "/$","" }
+$path = Join-Path $Env:TEMP "test.xlsx"
 
 $data = ConvertFrom-Csv -InputObject @"
 ID,Product,Quantity,Price
@@ -299,7 +300,7 @@ Describe "Conditional Formatting" {
     }
 
 }
-$path = "$Env:TEMP\test.xlsx"
+$path = Join-Path $Env:TEMP "test.xlsx"
 $data2 = ConvertFrom-Csv -InputObject @"
 ID,Product,Quantity,Price,Total
 12001,Nails,37,3.99,147.63
@@ -320,7 +321,7 @@ ID,Product,Quantity,Price,Total
 
 Describe "AutoNameRange data with a single property name" {
     BeforeEach {
-        $xlfile = "$Env:TEMP\testNamedRange.xlsx"
+        $xlfile = Join-Path $Env:TEMP "testNamedRange.xlsx"
         Remove-Item $xlfile -ErrorAction SilentlyContinue
     }
 

--- a/__tests__/Validation.tests.ps1
+++ b/__tests__/Validation.tests.ps1
@@ -1,3 +1,7 @@
+Import-Module $PSScriptRoot\..\ImportExcel.psd1 -Force
+if (-not $env:TEMP) {$env:TEMP = [IO.Path]::GetTempPath() -replace "/$","" }
+$notWindows =  ($PSVersionTable.os -and $PSVersionTable.os -notMatch 'Windows' )
+
 $data = ConvertFrom-Csv -InputObject @"
 ID,Product,Quantity,Price
 12001,Nails,37,3.99
@@ -7,7 +11,7 @@ ID,Product,Quantity,Price
 12011,Crowbar,7,23.48
 "@
 
-$path = "$Env:TEMP\DataValidation.xlsx"
+$path = Join-Path $Env:TEMP "DataValidation.xlsx"
 
 Describe "Data validation and protection" {
     Context "Data Validation rules" {


### PR DESCRIPTION
Also found that Export-Excel traps and warns when there is a problem with autosizing (which happens on non windows platforms) bit the Set-ExcelRange did not, so add a try {} catch {write-warning} to the latter.
Mostly fixing tests so that 
1. Windows only tests don't attempt to run on non-windows systems
2. Tests based on Get-Process don't attempt to run if <20 processes are returned. 
3. IF $env:TEMP is not set (as will be the case on linux). it is set 
4  Join-Path if used so paths are built with / or with \ as suits the OS where the test is running.

 