### PR TITLE
Move Append and ClearSheet check out of try block

### DIFF
--- a/Export-Excel.ps1
+++ b/Export-Excel.ps1
@@ -519,13 +519,13 @@
     )
 
     begin {
+        if ($Append -and $ClearSheet) {throw "You can't use -Append AND -ClearSheet."}
         $numberRegex = [Regex]'\d'
         $isDataTypeValueType = $false
         if ($NoClobber) {Write-Warning -Message "-NoClobber parameter is no longer used" }
         #Open the file, get the worksheet, and decide where in the sheet we are writing, and if there is a number format to apply.
         try   {
             $script:Header = $null
-            if ($Append -and $ClearSheet) {throw "You can't use -Append AND -ClearSheet."}
             $TableName = if ($null -eq $TableName -or ($TableName -is [bool] -and $false -eq $TableName)) { $null } else {[String]$TableName}
             if ($PSBoundParameters.Keys.Count -eq 0 -Or $Now -or (-not $Path -and -not $ExcelPackage) ) {
                 if (-not $PSBoundParameters.ContainsKey("Path")) { $Path = [System.IO.Path]::GetTempFileName() -replace '\.tmp', '.xlsx' }


### PR DESCRIPTION
The caller was told that the Excel package couldn't be open and the information about the usage of the Append and ClearSheet error was lost. I solved the problem by moving the check outside of the open file try block.