### PR TITLE
Standardising casing of parameter names

### DIFF
--- a/Public/Add-ConditionalFormatting.ps1
+++ b/Public/Add-ConditionalFormatting.ps1
@@ -87,7 +87,7 @@
     if     ($Reverse)  {
             if     ($rule.type -match 'IconSet$'   )                {$rule.reverse = $true}
             elseif ($rule.type -match 'ColorScale$')                {$temp =$rule.LowValue.Color ; $rule.LowValue.Color = $rule.HighValue.Color; $rule.HighValue.Color = $temp}
-            else   {Write-Warning -Message "-Reverse was ignored because $ruletype does not support it."}
+            else   {Write-Warning -Message "-Reverse was ignored because $RuleType does not support it."}
     }
     #endregion
     #region set the rule conditions

--- a/Public/Add-ExcelName.ps1
+++ b/Public/Add-ExcelName.ps1
@@ -11,7 +11,7 @@ function Add-ExcelName {
         $ws = $Range.Worksheet
         if (-not $RangeName) {
             $RangeName = $ws.Cells[$Range.Start.Address].Value
-            $Range  = ($Range.Worksheet.cells[($range.start.row +1), $range.start.Column ,  $range.end.row, $range.end.column])
+            $Range  = ($Range.Worksheet.cells[($Range.start.row +1), $Range.start.Column ,  $Range.end.row, $Range.end.column])
         }
         if ($RangeName -match '\W') {
             Write-Warning -Message "Range name '$RangeName' contains illegal characters, they will be replaced with '_'."

--- a/Public/Add-PivotTable.ps1
+++ b/Public/Add-PivotTable.ps1
@@ -96,8 +96,8 @@
                 $pivotTable = $wsPivot.PivotTables.Add($Address, $SourceWorkSheet.Cells[$SourceRange], $pivotTableName)
             }
             else {Write-warning "Could not create a PivotTable with the Source Range provided."; return}
-            foreach ($Row in $PivotRows) {
-                try {$null = $pivotTable.RowFields.Add($pivotTable.Fields[$Row]) }
+            foreach ($row in $PivotRows) {
+                try {$null = $pivotTable.RowFields.Add($pivotTable.Fields[$row]) }
                 catch {Write-Warning -message "Could not add '$row' to Rows in PivotTable $pivotTableName." }
             }
             foreach ($Column in $PivotColumns) {

--- a/Public/Convert-ExcelRangeToImage.ps1
+++ b/Public/Convert-ExcelRangeToImage.ps1
@@ -3,56 +3,56 @@
     param (
         [parameter(Mandatory=$true)]
         $Path,
-        $workSheetname = "Sheet1" ,
+        $WorksheetName = "Sheet1" ,
         [parameter(Mandatory=$true)]
-        $range,
-        $destination = "$pwd\temp.png",
-        [switch]$show
+        $Range,
+        $Destination = "$pwd\temp.png",
+        [switch]$Show
     )
-        $extension   = $destination -replace '^.*\.(\w+)$' ,'$1'
+        $extension   = $Destination -replace '^.*\.(\w+)$' ,'$1'
         if ($extension -in @('JPEG','BMP','PNG'))  {
             $Format = [system.Drawing.Imaging.ImageFormat]$extension
         }       #if we don't recognise the extension OR if it is JPG with an E, use JPEG format
         else { $Format = [system.Drawing.Imaging.ImageFormat]::Jpeg}
-        Write-Progress -Activity "Exporting $range of $workSheetname in $Path" -Status "Starting Excel"
+        Write-Progress -Activity "Exporting $Range of $WorksheetName in $Path" -Status "Starting Excel"
         $xlApp  = New-Object -ComObject "Excel.Application"
-        Write-Progress -Activity "Exporting $range of $workSheetname in $Path" -Status "Opening Workbook and copying data"
+        Write-Progress -Activity "Exporting $Range of $WorksheetName in $Path" -Status "Opening Workbook and copying data"
         $xlWbk  = $xlApp.Workbooks.Open($Path)
-        $xlWbk.Worksheets($workSheetname).Select()
-        $null = $xlWbk.ActiveSheet.Range($range).Select()
+        $xlWbk.Worksheets($WorksheetName).Select()
+        $null = $xlWbk.ActiveSheet.Range($Range).Select()
         $null = $xlApp.Selection.Copy()
-        Write-Progress -Activity "Exporting $range of $workSheetname in $Path" -Status "Saving copied data"
+        Write-Progress -Activity "Exporting $Range of $WorksheetName in $Path" -Status "Saving copied data"
         # Get-Clipboard came in with PS5. Older versions can use [System.Windows.Clipboard] but it is ugly.
         $image  = Get-Clipboard -Format Image
-        $image.Save($destination, $Format)
-        Write-Progress -Activity "Exporting $range of $workSheetname in $Path" -Status "Closing Excel"
+        $image.Save($Destination, $Format)
+        Write-Progress -Activity "Exporting $Range of $WorksheetName in $Path" -Status "Closing Excel"
         $null = $xlWbk.ActiveSheet.Range("a1").Select()
         $null = $xlApp.Selection.Copy()
         $xlApp.Quit()
-        Write-Progress -Activity "Exporting $range of $workSheetname in $Path" -Completed
-        if ($show) {Start-Process -FilePath $destination}
-        else       {Get-Item      -Path     $destination}
+        Write-Progress -Activity "Exporting $Range of $WorksheetName in $Path" -Completed
+        if ($Show) {Start-Process -FilePath $Destination}
+        else       {Get-Item      -Path     $Destination}
 }
 <#
 del demo*.xlsx
 
-$workSheetname = 'Processes'
+$worksheetName = 'Processes'
 $Path          = "$pwd\demo.xlsx"
 $myData        = Get-Process | Select-Object -Property Name,WS,CPU,Description,company,startTime
 
-$excelPackage  = $myData | Export-Excel -KillExcel -Path $Path -WorkSheetname $workSheetname -ClearSheet -AutoSize -AutoFilter -BoldTopRow -FreezeTopRow -PassThru
-$workSheet     = $excelPackage.Workbook.Worksheets[$workSheetname]
-$range         = $workSheet.Dimension.Address
-Set-ExcelRange                -Worksheet $workSheet -Range "b:b"      -NumberFormat "#,###"            -AutoFit
-Set-ExcelRange                -Worksheet $workSheet -Range "C:C"      -NumberFormat "#,##0.00"         -AutoFit
-Set-ExcelRange                -Worksheet $workSheet -Range "F:F"      -NumberFormat "dd MMMM HH:mm:ss" -AutoFit
-Add-ConditionalFormatting -Worksheet $workSheet -Range "c2:c1000" -DataBarColor Blue
-Add-ConditionalFormatting -Worksheet $workSheet -Range "b2:B1000" -RuleType GreaterThan -ConditionValue '104857600' -ForeGroundColor "Red" -Bold
+$excelPackage  = $myData | Export-Excel -KillExcel -Path $Path -WorkSheetname $worksheetName -ClearSheet -AutoSize -AutoFilter -BoldTopRow -FreezeTopRow -PassThru
+$worksheet     = $excelPackage.Workbook.Worksheets[$worksheetName]
+$range         = $worksheet.Dimension.Address
+Set-ExcelRange                -Worksheet $worksheet -Range "b:b"      -NumberFormat "#,###"            -AutoFit
+Set-ExcelRange                -Worksheet $worksheet -Range "C:C"      -NumberFormat "#,##0.00"         -AutoFit
+Set-ExcelRange                -Worksheet $worksheet -Range "F:F"      -NumberFormat "dd MMMM HH:mm:ss" -AutoFit
+Add-ConditionalFormatting -Worksheet $worksheet -Range "c2:c1000" -DataBarColor Blue
+Add-ConditionalFormatting -Worksheet $worksheet -Range "b2:B1000" -RuleType GreaterThan -ConditionValue '104857600' -ForeGroundColor "Red" -Bold
 
-Export-Excel -ExcelPackage $excelPackage -WorkSheetname $workSheetname
+Export-Excel -ExcelPackage $excelPackage -WorksheetName $worksheetName
 
-Convert-ExcelRangeToImage -Path $Path -workSheetname $workSheetname -range $range -destination  "$pwd\temp.png"  -show
+Convert-ExcelRangeToImage -Path $Path -WorksheetName $worksheetName -range $range -destination  "$pwd\temp.png"  -show
 #>
 
 
-#Convert-ExcelRangeToImage -Path $Path -workSheetname $workSheetname -range $range -destination  "$pwd\temp.png"  -show
+#Convert-ExcelRangeToImage -Path $Path -WorksheetName $worksheetName -range $range -destination  "$pwd\temp.png"  -show

--- a/Public/ConvertFrom-ExcelData.ps1
+++ b/Public/ConvertFrom-ExcelData.ps1
@@ -7,7 +7,7 @@ function ConvertFrom-ExcelData {
         $Path,
         [ScriptBlock]$scriptBlock,
         [Alias("Sheet")]
-        $WorkSheetname = 1,
+        $WorksheetName = 1,
         [int]$HeaderRow = 1,
         [string[]]$Header,
         [switch]$NoHeader,

--- a/Public/ConvertFrom-ExcelToSQLInsert.ps1
+++ b/Public/ConvertFrom-ExcelToSQLInsert.ps1
@@ -8,7 +8,7 @@ function ConvertFrom-ExcelToSQLInsert {
         [ValidateScript( { Test-Path $_ -PathType Leaf })]
         $Path,
         [Alias("Sheet")]
-        $WorkSheetname = 1,
+        $WorksheetName = 1,
         [Alias('HeaderRow', 'TopRow')]
         [ValidateRange(1, 9999)]
         [Int]$StartRow,

--- a/Public/Copy-ExcelWorksheet.ps1
+++ b/Public/Copy-ExcelWorksheet.ps1
@@ -52,7 +52,7 @@
             else {
                 $SourceObject = (Resolve-Path $SourceObject).ProviderPath
                 try {
-                    Write-Verbose "Opening worksheet '$Worksheetname' in Excel workbook '$SourceObject'."
+                    Write-Verbose "Opening worksheet '$WorksheetName' in Excel workbook '$SourceObject'."
                     $stream = New-Object -TypeName System.IO.FileStream -ArgumentList $SourceObject, 'Open', 'Read' , 'ReadWrite'
                     $package1 = New-Object -TypeName OfficeOpenXml.ExcelPackage -ArgumentList $stream
                     $sourceWs = $Package1.Workbook.Worksheets[$SourceWorkSheet]

--- a/Public/Export-Excel.ps1
+++ b/Public/Export-Excel.ps1
@@ -132,7 +132,7 @@
                 $WorksheetName = $ws.Name
             }
         }
-        catch {throw "Could not get worksheet $worksheetname"}
+        catch {throw "Could not get worksheet $WorksheetName"}
         try   {
             if ($Append -and $ws.Dimension) {
                 #if there is a title or anything else above the header row, append needs to be combined wih a suitable startrow parameter
@@ -176,23 +176,23 @@
             }
             elseif ($Title) {
                 #Can only add a title if not appending!
-                $Row = $StartRow
-                $ws.Cells[$Row, $StartColumn].Value = $Title
-                $ws.Cells[$Row, $StartColumn].Style.Font.Size = $TitleSize
+                $row = $StartRow
+                $ws.Cells[$row, $StartColumn].Value = $Title
+                $ws.Cells[$row, $StartColumn].Style.Font.Size = $TitleSize
 
                 if  ($PSBoundParameters.ContainsKey("TitleBold")) {
                     #Set title to Bold face font if -TitleBold was specified.
                     #Otherwise the default will be unbolded.
-                    $ws.Cells[$Row, $StartColumn].Style.Font.Bold = [boolean]$TitleBold
+                    $ws.Cells[$row, $StartColumn].Style.Font.Bold = [boolean]$TitleBold
                 }
                 if ($TitleBackgroundColor ) {
                     if ($TitleBackgroundColor -is [string])         {$TitleBackgroundColor = [System.Drawing.Color]::$TitleBackgroundColor }
-                    $ws.Cells[$Row, $StartColumn].Style.Fill.PatternType = $TitleFillPattern
-                    $ws.Cells[$Row, $StartColumn].Style.Fill.BackgroundColor.SetColor($TitleBackgroundColor)
+                    $ws.Cells[$row, $StartColumn].Style.Fill.PatternType = $TitleFillPattern
+                    $ws.Cells[$row, $StartColumn].Style.Fill.BackgroundColor.SetColor($TitleBackgroundColor)
                 }
-                $Row ++ ; $startRow ++
+                $row ++ ; $startRow ++
             }
-            else {  $Row = $StartRow }
+            else {  $row = $StartRow }
             $ColumnIndex = $StartColumn
             $Numberformat = Expand-NumberFormat -NumberFormat $Numberformat
             if ((-not $ws.Dimension) -and ($Numberformat -ne $ws.Cells.Style.Numberformat.Format)) {
@@ -278,20 +278,20 @@
                     foreach ($exclusion in $ExcludeProperty) {$script:Header = $script:Header -notlike $exclusion}
                     if ($NoHeader) {
                         # Don't push the headers to the spreadsheet
-                        $Row -= 1
+                        $row -= 1
                     }
                     else {
                         $ColumnIndex = $StartColumn
                         foreach ($Name in $script:Header) {
-                            $ws.Cells[$Row, $ColumnIndex].Value = $Name
-                            Write-Verbose "Cell '$Row`:$ColumnIndex' add header '$Name'"
+                            $ws.Cells[$row, $ColumnIndex].Value = $Name
+                            Write-Verbose "Cell '$row`:$ColumnIndex' add header '$Name'"
                             $ColumnIndex += 1
                         }
                     }
                 }
                 #endregion
                 #region Add non header values
-                $Row += 1
+                $row += 1
                 $ColumnIndex = $StartColumn
                 <#
                  For each item in the header OR for the Data item if this is a simple Type or data table :
@@ -305,39 +305,39 @@
                     else {$v = $TargetData.$Name}
                     try   {
                         if     ($v -is    [DateTime]) {
-                            $ws.Cells[$Row, $ColumnIndex].Value = $v
-                            $ws.Cells[$Row, $ColumnIndex].Style.Numberformat.Format = 'm/d/yy h:mm' # This is not a custom format, but a preset recognized as date and localized.
+                            $ws.Cells[$row, $ColumnIndex].Value = $v
+                            $ws.Cells[$row, $ColumnIndex].Style.Numberformat.Format = 'm/d/yy h:mm' # This is not a custom format, but a preset recognized as date and localized.
                         }
                         elseif ($v -is    [TimeSpan]) {
-                            $ws.Cells[$Row, $ColumnIndex].Value = $v
-                            $ws.Cells[$Row, $ColumnIndex].Style.Numberformat.Format = '[h]:mm:ss'
+                            $ws.Cells[$row, $ColumnIndex].Value = $v
+                            $ws.Cells[$row, $ColumnIndex].Style.Numberformat.Format = '[h]:mm:ss'
                         }
                         elseif ($v -is    [System.ValueType]) {
-                            $ws.Cells[$Row, $ColumnIndex].Value = $v
-                            if ($setNumformat) {$ws.Cells[$Row, $ColumnIndex].Style.Numberformat.Format = $Numberformat }
+                            $ws.Cells[$row, $ColumnIndex].Value = $v
+                            if ($setNumformat) {$ws.Cells[$row, $ColumnIndex].Style.Numberformat.Format = $Numberformat }
                         }
                         elseif ($v -is    [uri] ) {
-                            $ws.Cells[$Row, $ColumnIndex].HyperLink = $v
-                            $ws.Cells[$Row, $ColumnIndex].Style.Font.Color.SetColor([System.Drawing.Color]::Blue)
-                            $ws.Cells[$Row, $ColumnIndex].Style.Font.UnderLine = $true
+                            $ws.Cells[$row, $ColumnIndex].HyperLink = $v
+                            $ws.Cells[$row, $ColumnIndex].Style.Font.Color.SetColor([System.Drawing.Color]::Blue)
+                            $ws.Cells[$row, $ColumnIndex].Style.Font.UnderLine = $true
                         }
                         elseif ($v -isnot [String] ) { #Other objects or null.
-                            if ($null -ne $v) { $ws.Cells[$Row, $ColumnIndex].Value = $v.toString()}
+                            if ($null -ne $v) { $ws.Cells[$row, $ColumnIndex].Value = $v.toString()}
                         }
                         elseif ($v[0] -eq '=') {
-                            $ws.Cells[$Row, $ColumnIndex].Formula = ($v -replace '^=','')
-                            if ($setNumformat) {$ws.Cells[$Row, $ColumnIndex].Style.Numberformat.Format = $Numberformat }
+                            $ws.Cells[$row, $ColumnIndex].Formula = ($v -replace '^=','')
+                            if ($setNumformat) {$ws.Cells[$row, $ColumnIndex].Style.Numberformat.Format = $Numberformat }
                         }
                         elseif ( [System.Uri]::IsWellFormedUriString($v , [System.UriKind]::Absolute) ) {
                             if ($v -match "^xl://internal/") {
                                   $referenceAddress = $v -replace "^xl://internal/" , ""
                                   $display          = $referenceAddress -replace "!A1$"   , ""
                                   $h = New-Object -TypeName OfficeOpenXml.ExcelHyperLink -ArgumentList $referenceAddress , $display
-                                  $ws.Cells[$Row, $ColumnIndex].HyperLink = $h
+                                  $ws.Cells[$row, $ColumnIndex].HyperLink = $h
                             }
-                            else {$ws.Cells[$Row, $ColumnIndex].HyperLink = $v }   #$ws.Cells[$Row, $ColumnIndex].Value = $v.AbsoluteUri
-                            $ws.Cells[$Row, $ColumnIndex].Style.Font.Color.SetColor([System.Drawing.Color]::Blue)
-                            $ws.Cells[$Row, $ColumnIndex].Style.Font.UnderLine = $true
+                            else {$ws.Cells[$row, $ColumnIndex].HyperLink = $v }   #$ws.Cells[$row, $ColumnIndex].Value = $v.AbsoluteUri
+                            $ws.Cells[$row, $ColumnIndex].Style.Font.Color.SetColor([System.Drawing.Color]::Blue)
+                            $ws.Cells[$row, $ColumnIndex].Style.Font.UnderLine = $true
                         }
                         else {
                             $number = $null
@@ -346,15 +346,15 @@
                                  $NoNumberConversion -notcontains $Name -and
                                  [Double]::TryParse($v, [System.Globalization.NumberStyles]::Any, [System.Globalization.NumberFormatInfo]::CurrentInfo, [Ref]$number)
                                ) {
-                                 $ws.Cells[$Row, $ColumnIndex].Value = $number
-                                 if ($setNumformat) {$ws.Cells[$Row, $ColumnIndex].Style.Numberformat.Format = $Numberformat }
+                                 $ws.Cells[$row, $ColumnIndex].Value = $number
+                                 if ($setNumformat) {$ws.Cells[$row, $ColumnIndex].Style.Numberformat.Format = $Numberformat }
                             }
                             else {
-                                $ws.Cells[$Row, $ColumnIndex].Value  = $v
+                                $ws.Cells[$row, $ColumnIndex].Value  = $v
                             }
                         }
                     }
-                    catch {Write-Warning -Message "Could not insert the '$Name' property at Row $Row, Column $ColumnIndex"}
+                    catch {Write-Warning -Message "Could not insert the '$Name' property at Row $row, Column $ColumnIndex"}
                     $ColumnIndex += 1
                 }
                 $ColumnIndex -= 1 # column index will be the last column whether isDataTypeValueType was true or false
@@ -371,7 +371,7 @@
               $endAddress     = $ws.Dimension.End.Address
         }
         else {
-              $LastRow        = $Row
+              $LastRow        = $row
               $LastCol        = $ColumnIndex
               $endAddress     = [OfficeOpenXml.ExcelAddress]::GetAddress($LastRow , $LastCol)
         }

--- a/Public/Import-Excel.ps1
+++ b/Public/Import-Excel.ps1
@@ -115,7 +115,7 @@
             try {
                 #Select worksheet
                 if (-not  $WorksheetName) { $Worksheet = $ExcelPackage.Workbook.Worksheets[1] }
-                elseif (-not ($Worksheet = $ExcelPackage.Workbook.Worksheets[$WorkSheetName])) {
+                elseif (-not ($Worksheet = $ExcelPackage.Workbook.Worksheets[$WorksheetName])) {
                     throw "Worksheet '$WorksheetName' not found, the workbook only contains the worksheets '$($ExcelPackage.Workbook.Worksheets)'. If you only wish to select the first worksheet, please remove the '-WorksheetName' parameter." ; return
                 }
 
@@ -142,12 +142,12 @@
                 }
                 else {
                     $Columns = $StartColumn .. $EndColumn  ; if ($StartColumn -gt $EndColumn) { Write-Warning -Message "Selecting columns $StartColumn to $EndColumn might give odd results." }
-                    if ($NoHeader) { $Rows = $StartRow..$EndRow ; if ($StartRow -gt $EndRow) { Write-Warning -Message "Selecting rows $StartRow to $EndRow might give odd results." } }
-                    elseif ($HeaderName) { $Rows = $StartRow..$EndRow }
+                    if ($NoHeader) { $rows = $StartRow..$EndRow ; if ($StartRow -gt $EndRow) { Write-Warning -Message "Selecting rows $StartRow to $EndRow might give odd results." } }
+                    elseif ($HeaderName) { $rows = $StartRow..$EndRow }
                     else {
-                        $Rows = (1 + $StartRow)..$EndRow
+                        $rows = (1 + $StartRow)..$EndRow
                         if ($StartRow -eq 1 -and $EndRow -eq 1) {
-                            $Rows = 0
+                            $rows = 0
                         }
                     }
 
@@ -162,7 +162,7 @@
                     throw "Duplicate column headers found on row '$StartRow' in columns '$($Duplicates.Group.Column)'. Column headers must be unique, if this is not a requirement please use the '-NoHeader' or '-HeaderName' parameter."; return
                 }
                 #endregion
-                if (-not $Rows) {
+                if (-not $rows) {
                     Write-Warning "Worksheet '$WorksheetName' in workbook '$Path' contains no data in the rows after top row '$StartRow'"
                 }
                 else {
@@ -186,7 +186,7 @@
                         $TextColRegEx = New-Object -TypeName regex -ArgumentList $TextColExpression , 9
                     }
                     else {$TextColRegEx = $null}
-                    foreach ($R in $Rows) {
+                    foreach ($R in $rows) {
                         #Disabled write-verbose for speed
                         #  Write-Verbose "Import row '$R'"
                         $NewRow = [Ordered]@{ }
@@ -213,7 +213,7 @@
                     #endregion
                 }
             }
-            catch { throw "Failed importing the Excel workbook '$Path' with worksheet '$Worksheetname': $_"; return }
+            catch { throw "Failed importing the Excel workbook '$Path' with worksheet '$WorksheetName': $_"; return }
             finally {
                 if ($Path) { $stream.close(); $ExcelPackage.Dispose() }
             }

--- a/Public/Join-Worksheet.ps1
+++ b/Public/Join-Worksheet.ps1
@@ -7,7 +7,7 @@
         [Parameter(Mandatory = $true, ParameterSetName = "PackageDefault")]
         [Parameter(Mandatory = $true, ParameterSetName = "PackageTable")]
         [OfficeOpenXml.ExcelPackage]$ExcelPackage,
-        $WorkSheetName = 'Combined',
+        $WorksheetName = 'Combined',
         [switch]$Clearsheet,
         [switch]$NoHeader,
         [string]$FromLabel = "From" ,
@@ -55,10 +55,10 @@
     )
     #region get target worksheet, select it and move it to the end.
     if ($Path -and -not $ExcelPackage) {$ExcelPackage = Open-ExcelPackage -path $Path  }
-    $destinationSheet = Add-Worksheet -ExcelPackage $ExcelPackage -WorkSheetname $WorkSheetName -ClearSheet:$Clearsheet
+    $destinationSheet = Add-Worksheet -ExcelPackage $ExcelPackage -WorkSheetname $WorksheetName -ClearSheet:$Clearsheet
     foreach ($w in $ExcelPackage.Workbook.Worksheets) {$w.view.TabSelected = $false}
     $destinationSheet.View.TabSelected = $true
-    $ExcelPackage.Workbook.Worksheets.MoveToEnd($WorkSheetName)
+    $ExcelPackage.Workbook.Worksheets.MoveToEnd($WorksheetName)
     #row to insert at will be 1 on a blank sheet and lastrow + 1 on populated one
     $row = (1 + $destinationSheet.Dimension.End.Row )
     #endregion
@@ -123,7 +123,7 @@
     'Title', 'TitleFillPattern', 'TitleBackgroundColor', 'TitleBold', 'TitleSize' | ForEach-Object {$null = $params.Remove($_)}
     if ($params.Keys.Count) {
         if ($Title) { $params.StartRow = 2}
-        $params.WorkSheetName = $WorkSheetName
+        $params.WorkSheetName = $WorksheetName
         $params.ExcelPackage = $ExcelPackage
         Export-Excel @Params
     }

--- a/Public/Merge-MultipleSheets.ps1
+++ b/Public/Merge-MultipleSheets.ps1
@@ -84,7 +84,7 @@
          #All the 'difference' columns in the sheet are labeled with the file they came from, 'reference' columns need their
          #headers prefixed with the ref file name,  $colnames is the basis of a regular expression to identify what should have $refPrefix appended
          $colNames              = @("^_Row$")
-         if ($key -ne "*")
+         if ($Key -ne "*")
                {$colnames      += "^$Key$"}
          if ($filesToProcess.Count -ge 2) {
                $refPrefix       = (Split-Path -Path $filestoProcess[0] -Leaf) -replace "\.xlsx$"," "

--- a/Public/Set-ExcelColumn.ps1
+++ b/Public/Set-ExcelColumn.ps1
@@ -8,7 +8,7 @@
         [Parameter(ParameterSetName="Package",Mandatory=$true)]
         [OfficeOpenXml.ExcelPackage]$ExcelPackage,
         [Parameter(ParameterSetName="Package")]
-        [String]$Worksheetname = "Sheet1",
+        [String]$WorksheetName = "Sheet1",
         [Parameter(ParameterSetName="sheet",Mandatory=$true)]
         [OfficeOpenXml.ExcelWorksheet]$Worksheet,
         [Parameter(ValueFromPipeline=$true)]
@@ -52,10 +52,10 @@
     begin {
         #if we were passed a package object and a worksheet name , get the worksheet.
         if ($ExcelPackage)  {
-            if ($ExcelPackage.Workbook.Worksheets.Name -notcontains $Worksheetname) {
-                throw "The Workbook does not contain a sheet named '$Worksheetname'"
+            if ($ExcelPackage.Workbook.Worksheets.Name -notcontains $WorksheetName) {
+                throw "The Workbook does not contain a sheet named '$WorksheetName'"
             }
-            else {$Worksheet   = $ExcelPackage.Workbook.Worksheets[$Worksheetname] }
+            else {$Worksheet   = $ExcelPackage.Workbook.Worksheets[$WorksheetName] }
         }
 
         #In a script block to build a formula, we may want any of corners or the column name,
@@ -66,7 +66,7 @@
         $endRow                            = $Worksheet.Dimension.End.Row
     }
     process {
-        if ($null -eq $workSheet.Dimension) {Write-Warning "Can't format an empty worksheet."; return}
+        if ($null -eq $Worksheet.Dimension) {Write-Warning "Can't format an empty worksheet."; return}
         if ($Column  -eq 0 )  {$Column     = $endColumn    + 1 }
         $columnName = (New-Object 'OfficeOpenXml.ExcelCellAddress' @(1, $column)).Address -replace "1",""
         Write-Verbose -Message "Updating Column $columnName"
@@ -120,7 +120,7 @@
             Set-ExcelRange -Worksheet $Worksheet -Range $theRange @params
         }
         #endregion
-        if      ($PSBoundParameters.ContainsKey('Hide')) {$workSheet.Column($Column).Hidden = [bool]$Hide}
+        if      ($PSBoundParameters.ContainsKey('Hide')) {$Worksheet.Column($Column).Hidden = [bool]$Hide}
         #return the new data if -passthru was specified.
         if      ($PassThru)                 { $Worksheet.Column($Column)}
         elseif  ($ReturnRange)              { $theRange}

--- a/Public/Set-ExcelRow.ps1
+++ b/Public/Set-ExcelRow.ps1
@@ -8,7 +8,7 @@
         [Parameter(ParameterSetName="Package",Mandatory=$true)]
         [OfficeOpenXml.ExcelPackage]$ExcelPackage,
         [Parameter(ParameterSetName="Package")]
-        $Worksheetname = "Sheet1",
+        $WorksheetName = "Sheet1",
         [Parameter(ParameterSetName="Sheet",Mandatory=$true)]
         [OfficeOpenXml.Excelworksheet] $Worksheet,
         [Parameter(ValueFromPipeline = $true)]
@@ -53,10 +53,10 @@
     begin {
         #if we were passed a package object and a worksheet name , get the worksheet.
         if ($ExcelPackage)  {
-            if ($ExcelPackage.Workbook.Worksheets.Name -notcontains $Worksheetname) {
-                throw "The Workbook does not contain a sheet named '$Worksheetname'"
+            if ($ExcelPackage.Workbook.Worksheets.Name -notcontains $WorksheetName) {
+                throw "The Workbook does not contain a sheet named '$WorksheetName'"
             }
-            else {$Worksheet   = $ExcelPackage.Workbook.Worksheets[$Worksheetname] }
+            else {$Worksheet   = $ExcelPackage.Workbook.Worksheets[$WorksheetName] }
         }
         #In a script block to build a formula, we may want any of corners or the columnname,
         #if row and start column aren't specified assume first unused row, and first column
@@ -66,7 +66,7 @@
         $endRow                              = $Worksheet.Dimension.End.Row
     }
     process {
-        if ($null -eq $workSheet.Dimension) {Write-Warning "Can't format an empty worksheet."; return}
+        if ($null -eq $Worksheet.Dimension) {Write-Warning "Can't format an empty worksheet."; return}
         if      ($Row  -eq 0 ) {$Row         = $endRow + 1 }
         Write-Verbose -Message "Updating Row $Row"
         #Add a row label
@@ -117,7 +117,7 @@
             Set-ExcelRange -Worksheet $Worksheet -Range $theRange @params
         }
         #endregion
-        if ($PSBoundParameters.ContainsKey('Hide')) {$workSheet.Row($Row).Hidden = [bool]$Hide}
+        if ($PSBoundParameters.ContainsKey('Hide')) {$Worksheet.Row($Row).Hidden = [bool]$Hide}
         #return the new data if -passthru was specified.
         if     ($passThru)     {$Worksheet.Row($Row)}
         elseif ($ReturnRange)  {$theRange}


### PR DESCRIPTION
* standardise 'worksheet' as a single word, instead of 'workSheet' or 'WorkSheet'
* main parameter names starting with capital letter $WorksheetName
* supporting variable names starting with lower letter $worksheetName