### PR TITLE
Standardise examples: loading module + file cleanup

### DIFF
--- a/Examples/AddWorkSheet/AddMultiWorkSheet.ps1
+++ b/Examples/AddWorkSheet/AddMultiWorkSheet.ps1
@@ -1,8 +1,8 @@
 try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
 
-$xlSourcefile = "$env:TEMP\Source.xlsx"
+#Get rid of pre-exisiting sheet
+$xlSourcefile = "$env:TEMP\ImportExcelExample.xlsx"
 Write-Verbose -Verbose -Message  "Save location: $xlSourcefile"
-
 Remove-Item $xlSourcefile -ErrorAction Ignore
 
 #Put some simple data in a worksheet and Get an excel package object to represent the file

--- a/Examples/AddWorkSheet/AddWorkSheet.ps1
+++ b/Examples/AddWorkSheet/AddWorkSheet.ps1
@@ -1,7 +1,8 @@
 try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
 
-$xlSourcefile = "$env:TEMP\Source.xlsx"
-
+#Get rid of pre-exisiting sheet
+$xlSourcefile = "$env:TEMP\ImportExcelExample.xlsx"
+Write-Verbose -Verbose -Message  "Save location: $xlSourcefile"
 Remove-Item $xlSourcefile -ErrorAction Ignore
 
 #Put some simple data in a worksheet and Get an excel package object to represent the file

--- a/Examples/Charts/ChartAndTrendlines.ps1
+++ b/Examples/Charts/ChartAndTrendlines.ps1
@@ -1,7 +1,10 @@
 # Creates a worksheet, addes a chart and then a Linear trendline
+try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
 
-$xlfile = "$env:TEMP\trendLine.xlsx"
-Remove-Item $xlfile -ErrorAction SilentlyContinue
+#Get rid of pre-exisiting sheet
+$xlSourcefile = "$env:TEMP\ImportExcelExample.xlsx"
+Write-Verbose -Verbose -Message  "Save location: $xlSourcefile"
+Remove-Item $xlSourcefile -ErrorAction Ignore
 
 $data = ConvertFrom-Csv @"
 Region,Item,TotalSold
@@ -18,4 +21,4 @@ South,avocado,73
 "@
 
 $cd = New-ExcelChartDefinition -XRange Region -YRange TotalSold -ChartType ColumnClustered -ChartTrendLine Linear
-$data | Export-Excel $xlfile -ExcelChartDefinition $cd -AutoNameRange -Show
+$data | Export-Excel $xlSourcefile -ExcelChartDefinition $cd -AutoNameRange -Show

--- a/Examples/Charts/MultiSeries.ps1
+++ b/Examples/Charts/MultiSeries.ps1
@@ -1,6 +1,9 @@
 try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
 
-Remove-Item temp.xlsx -ErrorAction Ignore
+#Get rid of pre-exisiting sheet
+$xlSourcefile = "$env:TEMP\ImportExcelExample.xlsx"
+Write-Verbose -Verbose -Message  "Save location: $xlSourcefile"
+Remove-Item $xlSourcefile -ErrorAction Ignore
 
 $data = Invoke-Sum -data (Get-Process) -dimension Company -measure Handles, PM, VirtualMemorySize
 
@@ -11,4 +14,4 @@ $c = New-ExcelChartDefinition -Title "ProcessStats" `
     -SeriesHeader "PM","VM"
 
 $data |
-    Export-Excel -Path temp.xlsx -AutoSize -TableName Processes -ExcelChartDefinition $c  -Show
+    Export-Excel -Path $xlSourcefile -AutoSize -TableName Processes -ExcelChartDefinition $c  -Show

--- a/Examples/Charts/MultiSeries1.ps1
+++ b/Examples/Charts/MultiSeries1.ps1
@@ -1,6 +1,9 @@
 try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
 
-Remove-Item temp.xlsx -ErrorAction Ignore
+#Get rid of pre-exisiting sheet
+$xlSourcefile = "$env:TEMP\ImportExcelExample.xlsx"
+Write-Verbose -Verbose -Message  "Save location: $xlSourcefile"
+Remove-Item $xlSourcefile -ErrorAction Ignore
 
 $data = @"
 A,B,C,Date
@@ -15,5 +18,5 @@ $c = New-ExcelChartDefinition -Title Impressions `
     -SeriesHeader 'B data','A data' `
     -Row 0 -Column 0
 
-$data | ConvertFrom-Csv |   Export-Excel -path temp.xlsx -AutoSize -TableName Impressions
-Export-Excel -path temp.xlsx -worksheetName chartPage -ExcelChartDefinition $c  -show
+$data | ConvertFrom-Csv | Export-Excel -path $xlSourcefile -AutoSize -TableName Impressions
+Export-Excel -path $xlSourcefile -worksheetName chartPage -ExcelChartDefinition $c -show

--- a/Examples/Charts/MultipleCharts.ps1
+++ b/Examples/Charts/MultipleCharts.ps1
@@ -1,6 +1,9 @@
 try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
 
-Remove-Item -Path Tools.xlsx
+#Get rid of pre-exisiting sheet
+$xlSourcefile = "$env:TEMP\ImportExcelExample.xlsx"
+Write-Verbose -Verbose -Message  "Save location: $xlSourcefile"
+Remove-Item $xlSourcefile -ErrorAction Ignore
 
 $data = @"
 ID,Product,Quantity,Price,Total
@@ -16,4 +19,4 @@ $c2 = New-ExcelChartDefinition -YRange "Total   "-XRange "Product" -Title "Total
 $c3 = New-ExcelChartDefinition -YRange "Quantity"-XRange "Product" -Title "Sales volume" -NoLegend -Height 225 -Row 15
 
 $data | ConvertFrom-Csv |
-    Export-Excel -Path  "Tools.xlsx" -AutoFilter -AutoNameRange -AutoSize -ExcelChartDefinition $c1,$c2,$c3  -Show
+    Export-Excel -Path  $xlSourcefile -AutoFilter -AutoNameRange -AutoSize -ExcelChartDefinition $c1,$c2,$c3  -Show

--- a/Examples/Charts/NumberOfVisitors.ps1
+++ b/Examples/Charts/NumberOfVisitors.ps1
@@ -1,7 +1,9 @@
 ﻿try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
 
-$xlfile = "$env:TEMP\visitors.xlsx"
-Remove-Item $xlfile -ErrorAction SilentlyContinue
+#Get rid of pre-exisiting sheet
+$xlSourcefile = "$env:TEMP\ImportExcelExample.xlsx"
+Write-Verbose -Verbose -Message  "Save location: $xlSourcefile"
+Remove-Item $xlSourcefile -ErrorAction Ignore
 
 $data = ConvertFrom-Csv @"
 Week, TotalVisitors
@@ -25,5 +27,5 @@ $cd = New-ExcelChartDefinition `
     -NoLegend `
     -ChartTrendLine Linear
 
-$data | Export-Excel $xlfile -Show -AutoNameRange -AutoSize -TableName Visitors -ExcelChartDefinition $cd
+$data | Export-Excel $xlSourcefile -Show -AutoNameRange -AutoSize -TableName Visitors -ExcelChartDefinition $cd
 

--- a/Examples/Charts/NumberOfVisitors.ps1
+++ b/Examples/Charts/NumberOfVisitors.ps1
@@ -1,4 +1,6 @@
-﻿$xlfile = "$env:TEMP\visitors.xlsx"
+﻿try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
+
+$xlfile = "$env:TEMP\visitors.xlsx"
 Remove-Item $xlfile -ErrorAction SilentlyContinue
 
 $data = ConvertFrom-Csv @"

--- a/Examples/Charts/plot.ps1
+++ b/Examples/Charts/plot.ps1
@@ -10,8 +10,10 @@ function plot {
     $minx=[math]::Round($minx,1)
     $maxx=[math]::Round($maxx,1)
 
-    $file = 'C:\temp\plot.xlsx'
-    Remove-Item $file -ErrorAction Ignore
+    #Get rid of pre-exisiting sheet
+    $xlSourcefile = "$env:TEMP\ImportExcelExample.xlsx"
+    Write-Verbose -Verbose -Message  "Save location: $xlSourcefile"
+    Remove-Item $xlSourcefile -ErrorAction Ignore
 
    # $c = New-ExcelChart -XRange X -YRange Y -ChartType Line -NoLegend -Title Plot -Column 2 -ColumnOffSetPixels 35
 
@@ -20,7 +22,7 @@ function plot {
             X=$i.ToString("N1")
             Y=(&$f $i)
         }
-    }) | Export-Excel $file -Show -AutoNameRange -LineChart -NoLegend  #-ExcelChartDefinition $c
+    }) | Export-Excel $xlSourcefile -Show -AutoNameRange -LineChart -NoLegend  #-ExcelChartDefinition $c
 }
 
 function pi {[math]::pi}

--- a/Examples/ConditionalFormatting/ConditionalText.ps1
+++ b/Examples/ConditionalFormatting/ConditionalText.ps1
@@ -1,11 +1,13 @@
 try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
 
-$file = "$env:temp\conditionalTextFormatting.xlsx"
-Remove-Item $file -ErrorAction Ignore
+#Get rid of pre-exisiting sheet
+$xlSourcefile = "$env:TEMP\ImportExcelExample.xlsx"
+Write-Verbose -Verbose -Message  "Save location: $xlSourcefile"
+Remove-Item $xlSourcefile -ErrorAction Ignore
 
 Get-Service |
     Select-Object Status, Name, DisplayName, ServiceName |
-    Export-Excel $file -Show -AutoSize -AutoFilter -ConditionalText $(
+    Export-Excel $xlSourcefile -Show -AutoSize -AutoFilter -ConditionalText $(
         New-ConditionalText stop                                                  #Stop is the condition value, the rule is defaults to 'Contains text' and the default Colors are used
         New-ConditionalText runn darkblue cyan                                    #runn is the condition value, the rule is defaults to 'Contains text'; the foregroundColur is darkblue and the background is cyan
         New-ConditionalText -ConditionalType EndsWith svc wheat green             #the rule here is 'Ends with' and the value is 'svc' the forground is wheat and the background dark green

--- a/Examples/ConditionalFormatting/ContainsBlanks.ps1
+++ b/Examples/ConditionalFormatting/ContainsBlanks.ps1
@@ -12,8 +12,10 @@ $data = $(
     New-PSItem g h i
 )
 
-$file ="$env:temp\testblanks.xlsx"
+#Get rid of pre-exisiting sheet
+$xlSourcefile = "$env:TEMP\ImportExcelExample.xlsx"
+Write-Verbose -Verbose -Message  "Save location: $xlSourcefile"
+Remove-Item $xlSourcefile -ErrorAction Ignore
 
-Remove-Item $file -ErrorAction Ignore
 #use the conditional format definition created above
-$data | Export-Excel $file -show -ConditionalText $ContainsBlanks
+$data | Export-Excel $xlSourcefile -show -ConditionalText $ContainsBlanks

--- a/Examples/ConditionalFormatting/Databar.ps1
+++ b/Examples/ConditionalFormatting/Databar.ps1
@@ -1,12 +1,14 @@
 ﻿try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
 
-$path = "$env:temp\test.xlsx"
-Remove-Item -Path $path -ErrorAction Ignore
+#Get rid of pre-exisiting sheet
+$xlSourcefile = "$env:TEMP\ImportExcelExample.xlsx"
+Write-Verbose -Verbose -Message  "Save location: $xlSourcefile"
+Remove-Item $xlSourcefile -ErrorAction Ignore
 
 #Export processes, and get an ExcelPackage object representing the file.
 $excel = Get-Process |
     Select-Object -Property Name,Company,Handles,CPU,PM,NPM,WS |
-    Export-Excel -Path $path -ClearSheet -WorkSheetname "Processes" -PassThru
+    Export-Excel -Path $xlSourcefile -ClearSheet -WorkSheetname "Processes" -PassThru
 
 $sheet = $excel.Workbook.Worksheets["Processes"]
 

--- a/Examples/ConditionalFormatting/FormatCalculations.ps1
+++ b/Examples/ConditionalFormatting/FormatCalculations.ps1
@@ -1,8 +1,9 @@
 try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
 
-$f = "$env:TEMP\testExport.xlsx"
-
-Remove-Item $f -ErrorAction Ignore
+#Get rid of pre-exisiting sheet
+$xlSourcefile = "$env:TEMP\ImportExcelExample.xlsx"
+Write-Verbose -Verbose -Message  "Save location: $xlSourcefile"
+Remove-Item $xlSourcefile -ErrorAction Ignore
 
 $data = $(
 
@@ -25,6 +26,6 @@ $data = $(
 # the syntax is used is Export-excel -ConditionalText (New-Conditional text <parameters>) <other parameters>
 
 
-#$data  | Export-Excel $f -Show -AutoSize -ConditionalText (New-ConditionalText -ConditionalType AboveAverage)
-$data  | Export-Excel $f -Show -AutoSize -ConditionalText (New-ConditionalText -ConditionalType BelowAverage)
-#$data  | Export-Excel $f -Show -AutoSize -ConditionalText (New-ConditionalText -ConditionalType TopPercent)
+#$data  | Export-Excel $xlSourcefile -Show -AutoSize -ConditionalText (New-ConditionalText -ConditionalType AboveAverage)
+$data  | Export-Excel $xlSourcefile -Show -AutoSize -ConditionalText (New-ConditionalText -ConditionalType BelowAverage)
+#$data  | Export-Excel $xlSourcefile -Show -AutoSize -ConditionalText (New-ConditionalText -ConditionalType TopPercent)

--- a/Examples/ConditionalFormatting/GenDates.ps1
+++ b/Examples/ConditionalFormatting/GenDates.ps1
@@ -1,3 +1,5 @@
+try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
+
 function Get-DateOffset {
     param($days=0)
 

--- a/Examples/ConditionalFormatting/GetProcess.ps1
+++ b/Examples/ConditionalFormatting/GetProcess.ps1
@@ -1,12 +1,15 @@
 try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
 
-Remove-Item "$env:TEMP\testExport.xlsx" -ErrorAction Ignore
+#Get rid of pre-exisiting sheet
+$xlSourcefile = "$env:TEMP\ImportExcelExample.xlsx"
+Write-Verbose -Verbose -Message  "Save location: $xlSourcefile"
+Remove-Item $xlSourcefile -ErrorAction Ignore
 
 Get-Process | Where-Object Company | Select-Object Company, Name, PM, Handles, *mem* |
 
 #This example creates a 3 Icon set for the values in the "PM column, and Highlights company names (anywhere in the data) with different colors
 
-    Export-Excel "$env:TEMP\testExport.xlsx" -Show -AutoSize -AutoNameRange `
+    Export-Excel -Path $xlSourcefile -Show -AutoSize -AutoNameRange `
         -ConditionalFormat $(
             New-ConditionalFormattingIconSet -Range "C:C" `
                 -ConditionalFormat ThreeIconSet -IconType Arrows

--- a/Examples/ConditionalFormatting/Highlight-Last7Days.ps1
+++ b/Examples/ConditionalFormatting/Highlight-Last7Days.ps1
@@ -1,10 +1,11 @@
 try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
 
-$f = ".\testExport.xlsx"
-
-Remove-Item $f -ErrorAction Ignore
+#Get rid of pre-exisiting sheet
+$xlSourcefile = "$env:TEMP\ImportExcelExample.xlsx"
+Write-Verbose -Verbose -Message  "Save location: $xlSourcefile"
+Remove-Item $xlSourcefile -ErrorAction Ignore
 
 .\GenDates.ps1 |
-    Export-Excel $f -Show -AutoSize -ConditionalText $(
+    Export-Excel $xlSourcefile -Show -AutoSize -ConditionalText $(
         New-ConditionalText -ConditionalType Last7Days
     )

--- a/Examples/ConditionalFormatting/Highlight-LastMonth.ps1
+++ b/Examples/ConditionalFormatting/Highlight-LastMonth.ps1
@@ -1,10 +1,11 @@
 try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
 
-$f = ".\testExport.xlsx"
-
-Remove-Item $f -ErrorAction Ignore
+#Get rid of pre-exisiting sheet
+$xlSourcefile = "$env:TEMP\ImportExcelExample.xlsx"
+Write-Verbose -Verbose -Message  "Save location: $xlSourcefile"
+Remove-Item $xlSourcefile -ErrorAction Ignore
 
 .\GenDates.ps1 |
-    Export-Excel $f -Show -AutoSize -ConditionalText $(
+    Export-Excel $xlSourcefile -Show -AutoSize -ConditionalText $(
         New-ConditionalText -ConditionalType LastMonth
     )

--- a/Examples/ConditionalFormatting/Highlight-LastWeek.ps1
+++ b/Examples/ConditionalFormatting/Highlight-LastWeek.ps1
@@ -1,10 +1,11 @@
 try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
 
-$f = ".\testExport.xlsx"
-
-Remove-Item $f -ErrorAction Ignore
+#Get rid of pre-exisiting sheet
+$xlSourcefile = "$env:TEMP\ImportExcelExample.xlsx"
+Write-Verbose -Verbose -Message  "Save location: $xlSourcefile"
+Remove-Item $xlSourcefile -ErrorAction Ignore
 
 .\GenDates.ps1 |
-    Export-Excel $f -Show -AutoSize -ConditionalText $(
+    Export-Excel $xlSourcefile -Show -AutoSize -ConditionalText $(
         New-ConditionalText -ConditionalType LastWeek
     )

--- a/Examples/ConditionalFormatting/Highlight-NextMonth.ps1
+++ b/Examples/ConditionalFormatting/Highlight-NextMonth.ps1
@@ -1,10 +1,11 @@
 try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
 
-$f = ".\testExport.xlsx"
-
-Remove-Item $f -ErrorAction Ignore
+#Get rid of pre-exisiting sheet
+$xlSourcefile = "$env:TEMP\ImportExcelExample.xlsx"
+Write-Verbose -Verbose -Message  "Save location: $xlSourcefile"
+Remove-Item $xlSourcefile -ErrorAction Ignore
 
 .\GenDates.ps1 |
-    Export-Excel $f -Show -AutoSize -ConditionalText $(
+    Export-Excel $xlSourcefile -Show -AutoSize -ConditionalText $(
         New-ConditionalText -ConditionalType NextMonth
     )

--- a/Examples/ConditionalFormatting/Highlight-NextWeek.ps1
+++ b/Examples/ConditionalFormatting/Highlight-NextWeek.ps1
@@ -1,10 +1,11 @@
 try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
 
-$f = ".\testExport.xlsx"
-
-Remove-Item $f -ErrorAction Ignore
+#Get rid of pre-exisiting sheet
+$xlSourcefile = "$env:TEMP\ImportExcelExample.xlsx"
+Write-Verbose -Verbose -Message  "Save location: $xlSourcefile"
+Remove-Item $xlSourcefile -ErrorAction Ignore
 
 .\GenDates.ps1 |
-    Export-Excel $f -Show -AutoSize -ConditionalText $(
+    Export-Excel $xlSourcefile -Show -AutoSize -ConditionalText $(
         New-ConditionalText -ConditionalType NextWeek
     )

--- a/Examples/ConditionalFormatting/Highlight-ThisMonth.ps1
+++ b/Examples/ConditionalFormatting/Highlight-ThisMonth.ps1
@@ -1,10 +1,11 @@
 try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
 
-$f = ".\testExport.xlsx"
-
-Remove-Item $f -ErrorAction Ignore
+#Get rid of pre-exisiting sheet
+$xlSourcefile = "$env:TEMP\ImportExcelExample.xlsx"
+Write-Verbose -Verbose -Message  "Save location: $xlSourcefile"
+Remove-Item $xlSourcefile -ErrorAction Ignore
 
 .\GenDates.ps1 |
-    Export-Excel $f -Show -AutoSize -ConditionalText $(
+    Export-Excel $xlSourcefile -Show -AutoSize -ConditionalText $(
         New-ConditionalText -ConditionalType ThisMonth
     )

--- a/Examples/ConditionalFormatting/Highlight-ThisWeek.ps1
+++ b/Examples/ConditionalFormatting/Highlight-ThisWeek.ps1
@@ -1,10 +1,11 @@
 try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
 
-$f = ".\testExport.xlsx"
-
-Remove-Item $f -ErrorAction Ignore
+#Get rid of pre-exisiting sheet
+$xlSourcefile = "$env:TEMP\ImportExcelExample.xlsx"
+Write-Verbose -Verbose -Message  "Save location: $xlSourcefile"
+Remove-Item $xlSourcefile -ErrorAction Ignore
 
 .\GenDates.ps1 |
-    Export-Excel $f -Show -AutoSize -ConditionalText $(
+    Export-Excel $xlSourcefile -Show -AutoSize -ConditionalText $(
         New-ConditionalText -ConditionalType ThisWeek
     )

--- a/Examples/ConditionalFormatting/Highlight-Today.ps1
+++ b/Examples/ConditionalFormatting/Highlight-Today.ps1
@@ -1,10 +1,11 @@
 try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
 
-$f = ".\testExport.xlsx"
-
-Remove-Item $f -ErrorAction Ignore
+#Get rid of pre-exisiting sheet
+$xlSourcefile = "$env:TEMP\ImportExcelExample.xlsx"
+Write-Verbose -Verbose -Message  "Save location: $xlSourcefile"
+Remove-Item $xlSourcefile -ErrorAction Ignore
 
 .\GenDates.ps1 |
-    Export-Excel $f -Show -AutoSize -ConditionalText $(
+    Export-Excel $xlSourcefile -Show -AutoSize -ConditionalText $(
         New-ConditionalText -ConditionalType Today
     )

--- a/Examples/ConditionalFormatting/Highlight-Tomorrow.ps1
+++ b/Examples/ConditionalFormatting/Highlight-Tomorrow.ps1
@@ -1,10 +1,11 @@
 try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
 
-$f = ".\testExport.xlsx"
-
-Remove-Item $f -ErrorAction Ignore
+#Get rid of pre-exisiting sheet
+$xlSourcefile = "$env:TEMP\ImportExcelExample.xlsx"
+Write-Verbose -Verbose -Message  "Save location: $xlSourcefile"
+Remove-Item $xlSourcefile -ErrorAction Ignore
 
 .\GenDates.ps1 |
-    Export-Excel $f -Show -AutoSize -ConditionalText $(
+    Export-Excel $xlSourcefile -Show -AutoSize -ConditionalText $(
         New-ConditionalText -ConditionalType Tomorrow
     )

--- a/Examples/ConditionalFormatting/Highlight-Yesterday.ps1
+++ b/Examples/ConditionalFormatting/Highlight-Yesterday.ps1
@@ -1,10 +1,11 @@
 try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
 
-$f = ".\testExport.xlsx"
-
-Remove-Item $f -ErrorAction Ignore
+#Get rid of pre-exisiting sheet
+$xlSourcefile = "$env:TEMP\ImportExcelExample.xlsx"
+Write-Verbose -Verbose -Message  "Save location: $xlSourcefile"
+Remove-Item $xlSourcefile -ErrorAction Ignore
 
 .\GenDates.ps1 |
-    Export-Excel $f -Show -AutoSize -ConditionalText $(
+    Export-Excel $xlSourcefile -Show -AutoSize -ConditionalText $(
         New-ConditionalText -ConditionalType Yesterday
     )

--- a/Examples/ConditionalFormatting/HighlightDuplicates.ps1
+++ b/Examples/ConditionalFormatting/HighlightDuplicates.ps1
@@ -1,8 +1,9 @@
 try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
 
-$f = ".\testExport.xlsx"
-
-Remove-Item $f -ErrorAction Ignore
+#Get rid of pre-exisiting sheet
+$xlSourcefile = "$env:TEMP\ImportExcelExample.xlsx"
+Write-Verbose -Verbose -Message  "Save location: $xlSourcefile"
+Remove-Item $xlSourcefile -ErrorAction Ignore
 
 $data = $(
 
@@ -22,4 +23,4 @@ $data = $(
     New-PSItem SouthWest 11
 )
 
-$data  | Export-Excel $f -Show -AutoSize -ConditionalText (New-ConditionalText -ConditionalType DuplicateValues)
+$data  | Export-Excel $xlSourcefile -Show -AutoSize -ConditionalText (New-ConditionalText -ConditionalType DuplicateValues)

--- a/Examples/ConditionalFormatting/MonthlyTemperatuesDatabar.ps1
+++ b/Examples/ConditionalFormatting/MonthlyTemperatuesDatabar.ps1
@@ -1,6 +1,9 @@
 try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
 
-Remove-Item -Path .\test.xlsx -ErrorAction Ignore
+#Get rid of pre-exisiting sheet
+$xlSourcefile = "$env:TEMP\ImportExcelExample.xlsx"
+Write-Verbose -Verbose -Message  "Save location: $xlSourcefile"
+Remove-Item $xlSourcefile -ErrorAction Ignore
 
 $excel = @"
 Month,New York City,Austin Texas,Portland Oregon
@@ -17,7 +20,7 @@ Oct,65,82,63
 Nov,54,71,52
 Dec,44,63,46
 "@ | ConvertFrom-csv |
-    Export-Excel -Path .\test.xlsx -WorkSheetname Sheet1 -AutoNameRange -AutoSize -Title "Monthly Temperatures" -PassThru
+    Export-Excel -Path $xlSourcefile -WorkSheetname Sheet1 -AutoNameRange -AutoSize -Title "Monthly Temperatures" -PassThru
 
 $sheet = $excel.Workbook.Worksheets["Sheet1"]
 Add-ConditionalFormatting -Worksheet $sheet -Range "B1:D14" -DataBarColor CornflowerBlue

--- a/Examples/ConditionalFormatting/RangeFormatting.ps1
+++ b/Examples/ConditionalFormatting/RangeFormatting.ps1
@@ -1,7 +1,9 @@
 try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
 
-$f = ".\testExport.xlsx"
-Remove-Item $f -ErrorAction Ignore
+#Get rid of pre-exisiting sheet
+$xlSourcefile = "$env:TEMP\ImportExcelExample.xlsx"
+Write-Verbose -Verbose -Message  "Save location: $xlSourcefile"
+Remove-Item $xlSourcefile -ErrorAction Ignore
 
 function Get-DateOffset ($days=0) {
     (Get-Date).AddDays($days).ToShortDateString()
@@ -13,7 +15,7 @@ $(
     New-PSItem (Get-DateOffset -10) (Get-DateOffset -1)
 ) |
 
-    Export-Excel $f -Show -AutoSize -AutoNameRange -ConditionalText $(
+    Export-Excel $xlSourcefile -Show -AutoSize -AutoNameRange -ConditionalText $(
         New-ConditionalText -Range Start -ConditionalType Yesterday -ConditionalTextColor Red
         New-ConditionalText -Range End   -ConditionalType Yesterday -BackgroundColor Blue -ConditionalTextColor Red
     )

--- a/Examples/ConditionalFormatting/SalesReportWithDatabar.ps1
+++ b/Examples/ConditionalFormatting/SalesReportWithDatabar.ps1
@@ -1,6 +1,9 @@
 try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
 
-Remove-Item -Path .\test.xlsx -ErrorAction Ignore
+#Get rid of pre-exisiting sheet
+$xlSourcefile = "$env:TEMP\ImportExcelExample.xlsx"
+Write-Verbose -Verbose -Message  "Save location: $xlSourcefile"
+Remove-Item $xlSourcefile -ErrorAction Ignore
 
 $excel = @"
 Month,Sales
@@ -11,7 +14,7 @@ Apr,952
 May,770
 Jun,621
 "@ | ConvertFrom-csv |
-     Export-Excel -Path .\test.xlsx -WorkSheetname Sheet1 -AutoNameRange -PassThru
+     Export-Excel -Path $xlSourcefile -WorkSheetname Sheet1 -AutoNameRange -PassThru
 
 $sheet = $excel.Workbook.Worksheets["Sheet1"]
 Add-ConditionalFormatting -Worksheet $sheet -Range "B1:B7" -DataBarColor LawnGreen

--- a/Examples/ConditionalFormatting/TextComparisons.ps1
+++ b/Examples/ConditionalFormatting/TextComparisons.ps1
@@ -1,25 +1,29 @@
-try {Import-Module ..\..\ImportExcel.psd1 -Force} catch {throw ; return}
+    try {Import-Module ..\..\ImportExcel.psd1 -Force} catch {throw ; return}
 
-$data = $(
-    New-PSItem 100 @('test', 'testx')
-    New-PSItem 200
-    New-PSItem 300
-    New-PSItem 400
-    New-PSItem 500
-)
+    $data = $(
+        New-PSItem 100 @('test', 'testx')
+        New-PSItem 200
+        New-PSItem 300
+        New-PSItem 400
+        New-PSItem 500
+    )
 
-$file1 = "$env:Temp\tryComparison1.xlsx"
-$file2 = "$env:Temp\tryComparison2.xlsx"
+    #Get rid of pre-exisiting sheet
+    $xlSourcefile1 = "$env:TEMP\ImportExcelExample1.xlsx"
+    $xlSourcefile2 = "$env:TEMP\ImportExcelExample2.xlsx"
 
-Remove-Item -Path $file1 -ErrorAction Ignore
-Remove-Item -Path  $file2 -ErrorAction Ignore
+    Write-Verbose -Verbose -Message  "Save location: $xlSourcefile1"
+    Write-Verbose -Verbose -Message  "Save location: $xlSourcefile2"
 
-$data | Export-Excel $file1 -Show -ConditionalText $(
-    New-ConditionalText -ConditionalType GreaterThan 300
-    New-ConditionalText -ConditionalType LessThan 300 -BackgroundColor cyan
-)
+    Remove-Item $xlSourcefile1 -ErrorAction Ignore
+    Remove-Item $xlSourcefile2 -ErrorAction Ignore
 
-$data | Export-Excel $file2 -Show -ConditionalText $(
-    New-ConditionalText -ConditionalType GreaterThanOrEqual 275
-    New-ConditionalText -ConditionalType LessThanOrEqual 250 -BackgroundColor cyan
-)
+    $data | Export-Excel $xlSourcefile1 -Show -ConditionalText $(
+        New-ConditionalText -ConditionalType GreaterThan 300
+        New-ConditionalText -ConditionalType LessThan 300 -BackgroundColor cyan
+    )
+
+    $data | Export-Excel $xlSourcefile2 -Show -ConditionalText $(
+        New-ConditionalText -ConditionalType GreaterThanOrEqual 275
+        New-ConditionalText -ConditionalType LessThanOrEqual 250 -BackgroundColor cyan
+    )

--- a/Examples/ConditionalFormatting/Top10-DataBar-TwoColorScale.ps1
+++ b/Examples/ConditionalFormatting/Top10-DataBar-TwoColorScale.ps1
@@ -1,4 +1,6 @@
-﻿$xlfile = "$env:TEMP\test.xlsx"
+﻿try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
+
+$xlfile = "$env:TEMP\test.xlsx"
 Remove-Item $xlfile -ErrorAction SilentlyContinue
 
 $data = ConvertFrom-csv @"

--- a/Examples/ConditionalFormatting/Top10-DataBar-TwoColorScale.ps1
+++ b/Examples/ConditionalFormatting/Top10-DataBar-TwoColorScale.ps1
@@ -1,7 +1,9 @@
 ﻿try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
 
-$xlfile = "$env:TEMP\test.xlsx"
-Remove-Item $xlfile -ErrorAction SilentlyContinue
+#Get rid of pre-exisiting sheet
+$xlSourcefile = "$env:TEMP\ImportExcelExample.xlsx"
+Write-Verbose -Verbose -Message  "Save location: $xlSourcefile"
+Remove-Item $xlSourcefile -ErrorAction Ignore
 
 $data = ConvertFrom-csv @"
 Store,January,February,March,April,May,June
@@ -17,12 +19,12 @@ store01,21292,82341,81339,12505,29516,41634
 store82,74047,93325,25002,40113,76278,45707
 "@
 
-Export-Excel -InputObject $data -Path $xlfile -TableName RawData -WorksheetName RawData
-Export-Excel -InputObject $data -Path $xlfile -TableName TopData -WorksheetName StoresTop10Sales 
-Export-Excel -InputObject $data -Path $xlfile -TableName Databar -WorksheetName StoresSalesDataBar
-Export-Excel -InputObject $data -Path $xlfile -TableName TwoColorScale -WorksheetName StoresSalesTwoColorScale
+Export-Excel -InputObject $data -Path $xlSourcefile -TableName RawData -WorksheetName RawData
+Export-Excel -InputObject $data -Path $xlSourcefile -TableName TopData -WorksheetName StoresTop10Sales 
+Export-Excel -InputObject $data -Path $xlSourcefile -TableName Databar -WorksheetName StoresSalesDataBar
+Export-Excel -InputObject $data -Path $xlSourcefile -TableName TwoColorScale -WorksheetName StoresSalesTwoColorScale
 
-$xl = Open-ExcelPackage -Path $xlfile
+$xl = Open-ExcelPackage -Path $xlSourcefile
 
 Set-ExcelRange -Worksheet $xl.StoresTop10Sales -Range $xl.StoresTop10Sales.dimension.address -NumberFormat 'Currency' -AutoSize
 Set-ExcelRange -Worksheet $xl.StoresSalesDataBar -Range $xl.StoresSalesDataBar.dimension.address -NumberFormat 'Currency' -AutoSize

--- a/Examples/CustomReporting/CustomReport.ps1
+++ b/Examples/CustomReporting/CustomReport.ps1
@@ -1,7 +1,9 @@
 try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
 
-$f = "$env:temp\dashboard.xlsx"
-Remove-Item $f -ErrorAction Ignore
+#Get rid of pre-exisiting sheet
+$xlSourcefile = "$env:TEMP\ImportExcelExample.xlsx"
+Write-Verbose -Verbose -Message  "Save location: $xlSourcefile"
+Remove-Item $xlSourcefile -ErrorAction Ignore
 
 $data = @"
 From,To,RDollars,RPercent,MDollars,MPercent,Revenue,Margin
@@ -13,9 +15,9 @@ New York,San Francisco,3221000,.0629,1088000,.04,436,21
 New York,Phoneix,2782000,.0723,467000,.10,674,33
 "@ | ConvertFrom-Csv
 
-$data | Export-Excel $f -AutoSize
+$data | Export-Excel $xlSourcefile -AutoSize
 
-$excel = Open-ExcelPackage $f
+$excel = Open-ExcelPackage $xlSourcefile
 
 $sheet1 = $excel.Workbook.Worksheets["sheet1"]
 

--- a/Examples/ExcelBuiltIns/DSUM.ps1
+++ b/Examples/ExcelBuiltIns/DSUM.ps1
@@ -1,8 +1,11 @@
 # DSUM
 # Adds the numbers in a field (column) of records in a list or database that match conditions that you specify.
+try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
 
-$xlfile = "$env:TEMP\test.xlsx"
-Remove-Item $xlfile -ErrorAction SilentlyContinue
+#Get rid of pre-exisiting sheet
+$xlSourcefile = "$env:TEMP\ImportExcelExample.xlsx"
+Write-Verbose -Verbose -Message  "Save location: $xlSourcefile"
+Remove-Item $xlSourcefile -ErrorAction Ignore
 
 $data = ConvertFrom-Csv @"
 Color,Date,Sales
@@ -14,7 +17,7 @@ Red,1/17/2018,150
 Blue,1/17/2018,300
 "@
 
-$xl = Export-Excel -InputObject $data -Path $xlfile -AutoSize -AutoFilter -TableName SalesInfo -AutoNameRange -PassThru
+$xl = Export-Excel -InputObject $data -Path $xlSourcefile -AutoSize -AutoFilter -TableName SalesInfo -AutoNameRange -PassThru
 
 $databaseAddress = $xl.Sheet1.Dimension.Address
 Set-Format -Worksheet $xl.Sheet1 -Range C:C -NumberFormat '$##0'

--- a/Examples/ExcelBuiltIns/VLOOKUP.ps1
+++ b/Examples/ExcelBuiltIns/VLOOKUP.ps1
@@ -1,5 +1,9 @@
-﻿$xlfile = "$env:TEMP\test.xlsx"
-Remove-Item $xlfile -ErrorAction SilentlyContinue
+﻿try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
+
+#Get rid of pre-exisiting sheet
+$xlSourcefile = "$env:TEMP\ImportExcelExample.xlsx"
+Write-Verbose -Verbose -Message  "Save location: $xlSourcefile"
+Remove-Item $xlSourcefile -ErrorAction Ignore
 
 $data = ConvertFrom-Csv @"
 Fruit,Amount
@@ -9,11 +13,11 @@ Bananas,60
 Lemons,40
 "@
 
-$xl = Export-Excel -InputObject $data -Path $xlfile -PassThru -AutoSize
+$xl = Export-Excel -InputObject $data -Path $xlSourcefile -PassThru -AutoSize
 
 Set-ExcelRange -Worksheet $xl.Sheet1 -Range D2 -BackgroundColor LightBlue -Value Apples
 
-$Rows = $xl.Sheet1.Dimension.Rows
-Set-ExcelRange -Worksheet $xl.Sheet1 -Range E2 -Formula "=VLookup(D2,A2:B$($Rows),2,FALSE)"
+$rows = $xl.Sheet1.Dimension.Rows
+Set-ExcelRange -Worksheet $xl.Sheet1 -Range E2 -Formula "=VLookup(D2,A2:B$($rows),2,FALSE)"
 
 Close-ExcelPackage $xl -Show

--- a/Examples/ExcelDataValidation/MutipleValidations.ps1
+++ b/Examples/ExcelDataValidation/MutipleValidations.ps1
@@ -15,8 +15,10 @@
 
 try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
 
-$path = "$Env:TEMP\DataValidation.xlsx"
-Remove-Item $path -ErrorAction SilentlyContinue
+#Get rid of pre-exisiting sheet
+$xlSourcefile = "$env:TEMP\ImportExcelExample.xlsx"
+Write-Verbose -Verbose -Message  "Save location: $xlSourcefile"
+Remove-Item $xlSourcefile -ErrorAction Ignore
 
 $data = ConvertFrom-Csv -InputObject @"
 ID,Region,Product,Quantity,Price
@@ -29,7 +31,7 @@ ID,Region,Product,Quantity,Price
 
 # Export the raw data
 $excelPackage = $Data |
-    Export-Excel -WorksheetName "Sales" -Path $path -PassThru
+    Export-Excel -WorksheetName "Sales" -Path $xlSourcefile -PassThru
 
 # Creates a sheet with data that will be used in a validation rule
 $excelPackage = @('Chisel', 'Crowbar', 'Drill', 'Hammer', 'Nails', 'Saw', 'Screwdriver', 'Wrench') |

--- a/Examples/Experimental/tryExportMultipleExcelSheets.ps1
+++ b/Examples/Experimental/tryExportMultipleExcelSheets.ps1
@@ -1,7 +1,9 @@
 . "$PSScriptRoot\Export-MultipleExcelSheets.ps1"
 
-$xlfile = "$env:TEMP\test.xlsx"
-Remove-Item $xlfile -ErrorAction SilentlyContinue
+#Get rid of pre-exisiting sheet
+$xlSourcefile = "$env:TEMP\ImportExcelExample.xlsx"
+Write-Verbose -Verbose -Message  "Save location: $xlSourcefile"
+Remove-Item $xlSourcefile -ErrorAction Ignore
 
 $p = Get-Process
 
@@ -14,4 +16,4 @@ $InfoMap = @{
     WillNotGetExported = "Hello World"
 }
 
-Export-MultipleExcelSheets -Path $xlfile -InfoMap $InfoMap -Show -AutoSize
+Export-MultipleExcelSheets -Path $xlSourcefile -InfoMap $InfoMap -Show -AutoSize

--- a/Examples/Fibonacci/ShowFibonacci.ps1
+++ b/Examples/Fibonacci/ShowFibonacci.ps1
@@ -2,8 +2,10 @@ param ($fibonacciDigits=10)
 
 try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
 
-$file = "fib.xlsx"
-Remove-Item "fib.xlsx" -ErrorAction Ignore
+#Get rid of pre-exisiting sheet
+$xlSourcefile = "$env:TEMP\ImportExcelExample.xlsx"
+Write-Verbose -Verbose -Message  "Save location: $xlSourcefile"
+Remove-Item $xlSourcefile -ErrorAction Ignore
 
 $(
     New-PSItem 0
@@ -15,4 +17,4 @@ $(
                 New-PSItem ('=a{0}+a{1}' -f ($_+1),$_)
             }
     )
-) | Export-Excel $file -Show
+) | Export-Excel $xlSourcefile -Show

--- a/Examples/FormatCellStyles/ApplyFormatInScriptBlock.ps1
+++ b/Examples/FormatCellStyles/ApplyFormatInScriptBlock.ps1
@@ -1,10 +1,13 @@
 try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
 
-$xlfile = "$env:temp\testFmt.xlsx"
+#Get rid of pre-exisiting sheet
+$xlSourcefile = "$env:TEMP\ImportExcelExample.xlsx"
+Write-Verbose -Verbose -Message  "Save location: $xlSourcefile"
+Remove-Item $xlSourcefile -ErrorAction Ignore
 
 Get-Process |
     Select-Object Company,Handles,PM, NPM|
-    Export-Excel $xlfile -Show  -AutoSize -CellStyleSB {
+    Export-Excel $xlSourcefile  -Show  -AutoSize -CellStyleSB {
         param(
             $workSheet,
             $totalRows,

--- a/Examples/FormatCellStyles/ApplyStyle.ps1
+++ b/Examples/FormatCellStyles/ApplyStyle.ps1
@@ -1,4 +1,6 @@
-﻿$data = ConvertFrom-Csv @'
+﻿try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
+
+$data = ConvertFrom-Csv @'
 Item,Quantity,Price,Total Cost
 Footballs,9,21.95,197.55
 Cones,36,7.99,287.64

--- a/Examples/FormatCellStyles/PassInScriptBlock.ps1
+++ b/Examples/FormatCellStyles/PassInScriptBlock.ps1
@@ -1,7 +1,9 @@
 try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
 
-$xlfile = "$env:temp\testFmt.xlsx"
-Remove-Item $xlfile -ErrorAction Ignore
+#Get rid of pre-exisiting sheet
+$xlSourcefile = "$env:TEMP\ImportExcelExample.xlsx"
+Write-Verbose -Verbose -Message  "Save location: $xlSourcefile"
+Remove-Item $xlSourcefile -ErrorAction Ignore
 
 $RandomStyle = {
     param(
@@ -17,4 +19,4 @@ $RandomStyle = {
 
 Get-Process |
     Select-Object Company,Handles,PM, NPM|
-    Export-Excel $xlfile -Show  -AutoSize -CellStyleSB $RandomStyle
+    Export-Excel $xlSourcefile -Show  -AutoSize -CellStyleSB $RandomStyle

--- a/Examples/Grouping/GroupDate.ps1
+++ b/Examples/Grouping/GroupDate.ps1
@@ -1,10 +1,13 @@
-$xlfile = "$env:TEMP\Points.xlsx"
+try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
 
-Remove-Item $xlfile -ErrorAction SilentlyContinue
+#Get rid of pre-exisiting sheet
+$xlSourcefile = "$env:TEMP\ImportExcelExample.xlsx"
+Write-Verbose -Verbose -Message  "Save location: $xlSourcefile"
+Remove-Item $xlSourcefile -ErrorAction Ignore
 
 $PivotTableDefinition = New-PivotTableDefinition -Activate -PivotTableName Points `
     -PivotRows Driver, Date -PivotData @{Points = "SUM"} -GroupDateRow Date -GroupDatePart Years, Months
 
 Import-Csv "$PSScriptRoot\First10Races.csv" |
-    Select-Object  Race, @{n = "Date"; e = {[datetime]::ParseExact($_.date, "dd/MM/yyyy", (Get-Culture))}}, FinishPosition, Driver, GridPosition, Team, Points |
-    Export-Excel $xlfile -Show -AutoSize -PivotTableDefinition $PivotTableDefinition
+    Select-Object Race, @{n = "Date"; e = {[datetime]::ParseExact($_.date, "dd/MM/yyyy", (Get-Culture))}}, FinishPosition, Driver, GridPosition, Team, Points |
+    Export-Excel $xlSourcefile -Show -AutoSize -PivotTableDefinition $PivotTableDefinition

--- a/Examples/Grouping/GroupNumeric.ps1
+++ b/Examples/Grouping/GroupNumeric.ps1
@@ -1,10 +1,13 @@
-﻿$xlfile = "$env:TEMP\Places.xlsx"
+﻿try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
 
-Remove-Item $xlfile -ErrorAction SilentlyContinue
+#Get rid of pre-exisiting sheet
+$xlSourcefile = "$env:TEMP\ImportExcelExample.xlsx"
+Write-Verbose -Verbose -Message  "Save location: $xlSourcefile"
+Remove-Item $xlSourcefile -ErrorAction Ignore
 
 $PivotTableDefinition = New-PivotTableDefinition -Activate -PivotTableName Places `
     -PivotRows Driver, FinishPosition -PivotData @{Date = "Count"} -GroupNumericRow FinishPosition -GroupNumericMin 1 -GroupNumericMax 25 -GroupNumericInterval 3
 
 Import-Csv "$PSScriptRoot\First10Races.csv" |
     Select-Object  Race, @{n = "Date"; e = {[datetime]::ParseExact($_.date, "dd/MM/yyyy", (Get-Culture))}}, FinishPosition, Driver, GridPosition, Team, Points |
-    Export-Excel $xlfile -Show -AutoSize -PivotTableDefinition $PivotTableDefinition
+    Export-Excel $xlSourcefile -Show -AutoSize -PivotTableDefinition $PivotTableDefinition

--- a/Examples/Grouping/TimestampBucket.ps1
+++ b/Examples/Grouping/TimestampBucket.ps1
@@ -1,3 +1,4 @@
+try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
 $data = ConvertFrom-Csv @"
 Timestamp,Tenant
 10/29/2018 3:00:00.123,1
@@ -15,8 +16,10 @@ Timestamp,Tenant
 10/29/2018 3:02:00.999,1
 "@ | Select-Object @{n = 'Timestamp'; e = {Get-date $_.timestamp}}, tenant, @{n = 'Bucket'; e = { - (Get-date $_.timestamp).Second % 30}}
 
-$f = "$env:temp\pivottest.xlsx"
-Remove-Item $f -ErrorAction SilentlyContinue
+#Get rid of pre-exisiting sheet
+$xlSourcefile = "$env:TEMP\ImportExcelExample.xlsx"
+Write-Verbose -Verbose -Message  "Save location: $xlSourcefile"
+Remove-Item $xlSourcefile -ErrorAction Ignore
 
 $pivotDefParams = @{
     PivotTableName = 'Timestamp Buckets'
@@ -29,7 +32,7 @@ $pivotDefParams = @{
 
 $excelParams = @{
     PivotTableDefinition = New-PivotTableDefinition @pivotDefParams
-    Path                 = $f
+    Path                 = $xlSourcefile
     WorkSheetname        = "Log Data"
     AutoSize             = $true
     AutoFilter           = $true

--- a/Examples/HyperLinks/Races.ps1
+++ b/Examples/HyperLinks/Races.ps1
@@ -3,6 +3,7 @@
 #We will create links to each race in the first 10 rows of the spreadSheet
 #The next row will be column labels
 #After that will come a block for each race.
+try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
 
 #Read the data, and decide how much space to leave for the hyperlinks
 $scriptPath = Split-Path -Path $MyInvocation.MyCommand.path -Parent

--- a/Examples/JoinWorksheet/Join-Worksheet.sample.ps1
+++ b/Examples/JoinWorksheet/Join-Worksheet.sample.ps1
@@ -1,4 +1,6 @@
-﻿#Get rid of pre-exisiting sheet
+﻿try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
+
+#Get rid of pre-exisiting sheet
 $path = "$Env:TEMP\test.xlsx"
 remove-item -Path $path -ErrorAction SilentlyContinue
 

--- a/Examples/JoinWorksheet/Join-Worksheet.sample.ps1
+++ b/Examples/JoinWorksheet/Join-Worksheet.sample.ps1
@@ -1,8 +1,9 @@
 ﻿try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
 
 #Get rid of pre-exisiting sheet
-$path = "$Env:TEMP\test.xlsx"
-remove-item -Path $path -ErrorAction SilentlyContinue
+$xlSourcefile = "$env:TEMP\ImportExcelExample.xlsx"
+Write-Verbose -Verbose -Message  "Save location: $xlSourcefile"
+Remove-Item $xlSourcefile -ErrorAction Ignore
 
 #Create simple pages for 3 stores with product ID, Product Name, quanity price and total
 
@@ -13,7 +14,7 @@ ID,Product,Quantity,Price,Total
 12003,Saw,12,15.37,184.44
 12010,Drill,20,8,160
 12011,Crowbar,7,23.48,164.36
-"@ | ConvertFrom-Csv| Export-Excel -Path $path -WorkSheetname Oxford
+"@ | ConvertFrom-Csv| Export-Excel -Path $xlSourcefile -WorkSheetname Oxford
 
 @"
 ID,Product,Quantity,Price,Total
@@ -22,7 +23,7 @@ ID,Product,Quantity,Price,Total
 12003,Saw,10,15.37,153.70
 12010,Drill,10,8,80
 12012,Pliers,2,14.99,29.98
-"@ | ConvertFrom-Csv| Export-Excel -Path $path -WorkSheetname Abingdon
+"@ | ConvertFrom-Csv| Export-Excel -Path $xlSourcefile -WorkSheetname Abingdon
 
 
 @"
@@ -31,7 +32,7 @@ ID,Product,Quantity,Price,Total
 12002,Hammer,2,12.10,24.20
 12010,Drill,11,8,88
 12012,Pliers,3,14.99,44.97
-"@ | ConvertFrom-Csv| Export-Excel -Path $path -WorkSheetname Banbury
+"@ | ConvertFrom-Csv| Export-Excel -Path $xlSourcefile -WorkSheetname Banbury
 
 #define a pivot table with a chart to show a sales by store, broken down by product
 $ptdef = New-PivotTableDefinition -PivotTableName "Summary" -PivotRows "Store" -PivotColumns "Product" -PivotData @{"Total"="SUM"} -IncludePivotChart -ChartTitle "Sales Breakdown" -ChartType ColumnStacked -ChartColumn 10
@@ -42,4 +43,4 @@ $ptdef = New-PivotTableDefinition -PivotTableName "Summary" -PivotRows "Store" -
 #Put in a title and freeze to top of the sheet including title and colmun headings
 #Add the Pivot table.
 #Show the result
-Join-Worksheet -Path $path -WorkSheetName "Total" -Clearsheet -FromLabel "Store" -TableName "Combined" -TableStyle Light1 -AutoSize -BoldTopRow -FreezePane 2,1 -Title "Store Sales Summary" -TitleBold -TitleSize 14  -PivotTableDefinition $ptdef -show
+Join-Worksheet -Path $xlSourcefile -WorkSheetName "Total" -Clearsheet -FromLabel "Store" -TableName "Combined" -TableStyle Light1 -AutoSize -BoldTopRow -FreezePane 2,1 -Title "Store Sales Summary" -TitleBold -TitleSize 14  -PivotTableDefinition $ptdef -show

--- a/Examples/JoinWorksheet/Join-worksheet-blocks.sample.ps1
+++ b/Examples/JoinWorksheet/Join-worksheet-blocks.sample.ps1
@@ -1,14 +1,17 @@
 try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
 
-$path = "$env:TEMP\Test.xlsx"
-Remove-item -Path $path -ErrorAction SilentlyContinue
+#Get rid of pre-exisiting sheet
+$xlSourcefile = "$env:TEMP\ImportExcelExample.xlsx"
+Write-Verbose -Verbose -Message  "Save location: $xlSourcefile"
+Remove-Item $xlSourcefile -ErrorAction Ignore
+
 #Export disk volume, and Network adapter to their own sheets.
 Get-CimInstance -ClassName Win32_LogicalDisk   |
     Select-Object -Property DeviceId,VolumeName, Size,Freespace |
-        Export-Excel -Path $path -WorkSheetname Volumes -NumberFormat "0,000"
+        Export-Excel -Path $xlSourcefile -WorkSheetname Volumes -NumberFormat "0,000"
 Get-NetAdapter  |
     Select-Object -Property Name,InterfaceDescription,MacAddress,LinkSpeed |
-        Export-Excel -Path $path -WorkSheetname NetAdapters
+        Export-Excel -Path $xlSourcefile -WorkSheetname NetAdapters
 
 #Create a summary page with a title of Summary, label the blocks with the name of the sheet they came from and hide the source sheets
-Join-Worksheet -Path $path -HideSource -WorkSheetName Summary -NoHeader -LabelBlocks  -AutoSize -Title "Summary" -TitleBold -TitleSize 22 -show
+Join-Worksheet -Path $xlSourcefile -HideSource -WorkSheetName Summary -NoHeader -LabelBlocks  -AutoSize -Title "Summary" -TitleBold -TitleSize 22 -show

--- a/Examples/JoinWorksheet/Join-worksheet-blocks.sample.ps1
+++ b/Examples/JoinWorksheet/Join-worksheet-blocks.sample.ps1
@@ -1,3 +1,4 @@
+try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
 
 $path = "$env:TEMP\Test.xlsx"
 Remove-item -Path $path -ErrorAction SilentlyContinue

--- a/Examples/JoinWorksheet/JoinSalesData.ps1
+++ b/Examples/JoinWorksheet/JoinSalesData.ps1
@@ -1,15 +1,16 @@
 try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
 
-$xlfile = "$env:temp\AllSales.xlsx"
-
-Remove-Item $xlfile -ErrorAction Ignore
+#Get rid of pre-exisiting sheet
+$xlSourcefile = "$env:TEMP\ImportExcelExample.xlsx"
+Write-Verbose -Verbose -Message  "Save location: $xlSourcefile"
+Remove-Item $xlSourcefile -ErrorAction Ignore
 
 $params = @{
     AutoSize             = $true
     AutoFilter           = $true
     AutoNameRange        = $true
     ExcelChartDefinition = New-ExcelChartDefinition -XRange Item -YRange UnitSold -Title 'Units Sold'
-    Path                 = $xlfile
+    Path                 = $xlSourcefile
 }
 #Import 4 sets of sales data from 4 CSV files, using the parameters above.
 Import-Csv $PSScriptRoot\NorthSales.csv | Export-Excel -WorkSheetname North @params

--- a/Examples/MergeWorkSheet/MergeCSV.ps1
+++ b/Examples/MergeWorkSheet/MergeCSV.ps1
@@ -1,8 +1,9 @@
 try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
 
-$xlFile = "$env:TEMP\mw.xlsx"
-
-Remove-Item $xlFile -ErrorAction Ignore
+#Get rid of pre-exisiting sheet
+$xlSourcefile = "$env:TEMP\ImportExcelExample.xlsx"
+Write-Verbose -Verbose -Message  "Save location: $xlSourcefile"
+Remove-Item $xlSourcefile -ErrorAction Ignore
 
 $leftCsv = @"
 MyProp1,MyProp2,Length
@@ -16,4 +17,4 @@ a,b,10
 c,d,21
 "@ | ConvertFrom-Csv
 
-Merge-Worksheet -OutputFile $xlFile -ReferenceObject $leftCsv -DifferenceObject $rightCsv -Key Length -Show
+Merge-Worksheet -OutputFile $xlSourcefile -ReferenceObject $leftCsv -DifferenceObject $rightCsv -Key Length -Show

--- a/Examples/MergeWorkSheet/Merge_2_Servers_Services.ps1
+++ b/Examples/MergeWorkSheet/Merge_2_Servers_Services.ps1
@@ -1,3 +1,5 @@
+try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
+
 Remove-Item -Path  "$env:temp\server*.xlsx" , "$env:temp\Combined*.xlsx" -ErrorAction SilentlyContinue
 
 #Get a subset of services into $s and export them

--- a/Examples/MergeWorkSheet/Merge_3_Servers_Services.ps1
+++ b/Examples/MergeWorkSheet/Merge_3_Servers_Services.ps1
@@ -1,3 +1,5 @@
+try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
+
 Remove-Item -Path  "$env:temp\server*.xlsx" , "$env:temp\Combined*.xlsx" -ErrorAction SilentlyContinue
 
 #Get a subset of services into $s and export them

--- a/Examples/MortgageCalculator/MortgageCalculator.ps1
+++ b/Examples/MortgageCalculator/MortgageCalculator.ps1
@@ -7,7 +7,7 @@ param(
     $InterestRate = .065,
     $Term = 30
 )
-
+try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
 function New-CellData {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification='Does not change system state')]
     param(

--- a/Examples/PivotTable/TableAndPivotTable.ps1
+++ b/Examples/PivotTable/TableAndPivotTable.ps1
@@ -1,5 +1,9 @@
-$path = "$Env:TEMP\test.xlsx"
-remove-item -path $path -ErrorAction SilentlyContinue
+try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
+
+#Get rid of pre-exisiting sheet
+$xlSourcefile = "$env:TEMP\ImportExcelExample.xlsx"
+Write-Verbose -Verbose -Message  "Save location: $xlSourcefile"
+Remove-Item $xlSourcefile -ErrorAction Ignore
 
 #Export some sales data to Excel, format it as a table and put a data-bar in.  For this example we won't create the pivot table during the export
 $excel =  ConvertFrom-Csv    @"
@@ -10,7 +14,7 @@ Banana, London , 300, 200
 Orange, Paris,   600, 500
 Banana, Paris,   300, 200
 Apple, New York, 1200,700
-"@  | Export-Excel -PassThru  -Path $path  -TableStyle Medium13 -tablename "RawData" -ConditionalFormat @{Range="C2:C7"; DataBarColor="Green"}
+"@  | Export-Excel -PassThru -Path $xlSourcefile -TableStyle Medium13 -tablename "RawData" -ConditionalFormat @{Range="C2:C7"; DataBarColor="Green"}
 
 #Add a pivot table, specify its address to put it on the same sheet, use the data that was just exported  set the table style and number format.
 #Use the "City" for the row names, and "Product" for the columnnames, and sum both the gross and net values for each City/Product combination; add grand totals to rows and columns.


### PR DESCRIPTION
Added this to the top of the examples
`try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}`

Unified example file cleanup
```#Get rid of pre-exisiting sheet
$xlSourcefile = "$env:TEMP\ImportExcelExample.xlsx"
Write-Verbose -Verbose -Message  "Save location: $xlSourcefile"
Remove-Item $xlSourcefile -ErrorAction Ignore```