### PR TITLE
Add-ExcelName support for scope

### DIFF
--- a/Public/Add-ExcelName.ps1
+++ b/Public/Add-ExcelName.ps1
@@ -5,7 +5,9 @@ function Add-ExcelName {
         [Parameter(Mandatory=$true)]
         [OfficeOpenXml.ExcelRange]$Range,
         #The name to assign to the range. If the name exists it will be updated to the new range. If no name is specified, the first cell in the range will be used as the name.
-        [String]$RangeName
+        [String]$RangeName,
+        #targeting a worksheet scope prevents using the Named Range in data validation features.  In Excel the default scope is Workbook
+        [switch]$ForceSheetScope
     )
     try {
         $ws = $Range.Worksheet
@@ -17,13 +19,26 @@ function Add-ExcelName {
             Write-Warning -Message "Range name '$RangeName' contains illegal characters, they will be replaced with '_'."
             $RangeName = $RangeName -replace '\W','_'
         }
-        if ($ws.names[$RangeName]) {
-            Write-verbose -Message "Updating Named range '$RangeName' to $($Range.FullAddressAbsolute)."
-            $ws.Names[$RangeName].Address = $Range.FullAddressAbsolute
+        if ($ForceSheetScope) {
+            if ($ws.names[$RangeName]) {
+                Write-verbose -Message "Updating Named range (worksheet scope) '$RangeName' to $($Range.FullAddressAbsolute)."
+                $ws.Names[$RangeName].Address = $Range.FullAddressAbsolute
+            }
+            else  {
+                Write-verbose -Message "Creating Named range (worksheet scope) '$RangeName' as $($Range.FullAddressAbsolute)."
+                $null = $ws.Names.Add($RangeName, $Range)
+            }
         }
-        else  {
-            Write-verbose -Message "Creating Named range '$RangeName' as $($Range.FullAddressAbsolute)."
-            $null = $ws.Names.Add($RangeName, $Range)
+        else {
+            $wb = $ws.WorkBook
+            if ($wb.names[$RangeName]) {
+                Write-verbose -Message "Updating Named range (workbook scope) '$RangeName' to $($Range.FullAddressAbsolute)."
+                $wb.Names[$RangeName].Address = $Range.FullAddressAbsolute
+            }
+            else  {
+                Write-verbose -Message "Creating Named range (workbook scope) '$RangeName' as $($Range.FullAddressAbsolute)."
+                $null = $wb.Names.Add($RangeName, $Range)
+            }
         }
     }
     catch {Write-Warning -Message "Failed adding named range '$RangeName' to worksheet '$($ws.Name)': $_"  }


### PR DESCRIPTION
Excel creates Named Ranges using a Workbook scope, you must go out of your way to create in the WorkSheet scope.

I know this would mean a breaking change, but named ranges cannot be used in Data Validation scenarios, they are severely limited.

Obviously the switch can be inverted, but I feel it would be best to follow the same pattern as Excel