### PR TITLE
Fix UNC paths for ConvertFrom-ExcelSheet

### DIFF
--- a/Public/ConvertFrom-ExcelSheet.ps1
+++ b/Public/ConvertFrom-ExcelSheet.ps1
@@ -19,7 +19,7 @@ function ConvertFrom-ExcelSheet {
         [string[]]$AsDate = @()
     )
 
-    $Path = (Resolve-Path $Path).Path
+    $Path = (Resolve-Path $Path).ProviderPath
     $xl = New-Object -TypeName OfficeOpenXml.ExcelPackage -ArgumentList $Path
     $workbook = $xl.Workbook
 


### PR DESCRIPTION
UNC paths broken with just Path property of Resolve-Path, looks like it was fixed elsewhere but overlooked here.