### PR TITLE
Added compatibility for PS5 and lower

### DIFF
--- a/Public/Read-Clipboard.ps1
+++ b/Public/Read-Clipboard.ps1
@@ -22,7 +22,7 @@ function Read-Clipboard {
         $Header   
     )
     
-    if ($IsWindows) {
+    if ($IsWindows -or $PSVersionTable.PSEdition -eq "Desktop") {
         $osInfo = Get-CimInstance -ClassName Win32_OperatingSystem
         if ($osInfo.ProductType -eq 1) {
             $cvtParams = @{


### PR DESCRIPTION
Don't know whether the rest of the code would work, but as $IsWindows is not returning TRUE in PS v5, I thought to add $PSVersionTable.PSEdition -eq "Desktop"

fixes #1056