### PR TITLE
Update Add-Worksheet.ps1 - 'worsheet' to 'worksheet' in warnings

### DIFF
--- a/Public/Add-Worksheet.ps1
+++ b/Public/Add-Worksheet.ps1
@@ -49,7 +49,7 @@ function Add-Worksheet  {
             }
             else {$ExcelWorkbook.Worksheets.MoveBefore($WorksheetName, $MoveBefore)}
         }
-        else {Write-Warning "Can't find worksheet '$MoveBefore'; worsheet '$WorksheetName' will not be moved."}
+        else {Write-Warning "Can't find worksheet '$MoveBefore'; worksheet '$WorksheetName' will not be moved."}
     }
     elseif ($MoveAfter  ) {
         if ($MoveAfter -eq "*") {
@@ -68,7 +68,7 @@ function Add-Worksheet  {
                 $ExcelWorkbook.Worksheets.MoveAfter($WorksheetName, $MoveAfter)
             }
         }
-        else {Write-Warning "Can't find worksheet '$MoveAfter'; worsheet '$WorksheetName' will not be moved."}
+        else {Write-Warning "Can't find worksheet '$MoveAfter'; worksheet '$WorksheetName' will not be moved."}
     }
     #endregion
     if ($Activate) {Select-Worksheet -ExcelWorksheet $ws  }


### PR DESCRIPTION
Due to some foolishness on my part, I saw this warning several times, so the 'worsheet' typo started to get to me.