### PR TITLE
Update to parse date strings as OLE Date

### DIFF
--- a/Public/Import-Excel.ps1
+++ b/Public/Import-Excel.ps1
@@ -223,8 +223,31 @@
                                     if ($MatchTest.groups.name -eq "astext") {
                                         $NewRow[$P.Value] = $sheet.Cells[$R, $P.Column].Text
                                     }
-                                    elseif ($MatchTest.groups.name -eq "asdate" -and $sheet.Cells[$R, $P.Column].Value -is [System.ValueType]) {
-                                        $NewRow[$P.Value] = [datetime]::FromOADate(($sheet.Cells[$R, $P.Column].Value))
+                                    elseif ($MatchTest.groups.name -eq "asdate" -and $sheet.Cells[$R, $P.Column].Value -is [System.ValueType]) 
+                                    {
+                                        # Depending on how the source Excel document represents dates this may not work everytime
+                                        Try
+                                        {
+                                            # If the value here does not match a very specific DateTime pattern conversions will not take place and an error will be thrown
+                                            $NewRow[$P.Value] = [datetime]::FromOADate(($sheet.Cells[$R, $P.Column].Value))
+                                        }
+                                        Catch
+                                        {
+                                            # To rectify failures to parse we can try (2) methods
+                                            #   - 1: Attempt to Cast the string to DateTime and subtract the Excel Epoch
+                                            #   - 2: Convert the value to a vaild DateTime string and then cast / subtract from Epoch
+                                            Try
+                                            {
+                                                $Delta = [DateTime]($Sheet.Cells[$R, $P.Column].Value) - [DateTime]"12/30/1899"
+                                                $NewRow[$P.Value] = [DateTime]::FromOADate([Double]($Delta.Days) + ([Double]($Delta.Seconds) / 86400))
+                                            }
+                                            Catch
+                                            {
+                                                $DeltaString = ([DateTime]($Sheet.Cells[$R, $P.Column].Value)).ToString("dd-MM-yyyy")
+                                                $Delta = [DateTime]($DeltaString) - [DateTime]"12/30/1899"
+                                                $NewRow[$P.Value] = [DateTime]::FromOADate([Double]($Delta.Days) + ([Double]($Delta.Seconds) / 86400))
+                                            }
+                                        }
                                     }
                                     else { $NewRow[$P.Value] = $sheet.Cells[$R, $P.Column].Value }
                                 }


### PR DESCRIPTION
Ran into some issues while importing a fairly large Excel document and the date time formatting / column definitions within it not being consistent, this is the fix that worked to check and convert strings that normally "[DateTime]::FromOADate()" couldn't parse because well they're strings and not OLE Dates. It seems like a good addition to beef up the date parsing from imported documents to lessen the burden of defining column types in Excel but that is only my own opinion.