### PR TITLE
Fix issue 1344 with Set-ExcelRow/Set-ExcelRange

### DIFF
--- a/Public/Export-Excel.ps1
+++ b/Public/Export-Excel.ps1
@@ -494,7 +494,7 @@
             }
             elseif ($FreezeTopRow) {
                 if ($Title) {
-                    $ws.View.FreezePanes(2, 1)
+                    $ws.View.FreezePanes(3, 1)
                     Write-Verbose -Message "Froze title and header rows"
                 }
                 else {

--- a/Public/Set-ExcelRange.ps1
+++ b/Public/Set-ExcelRange.ps1
@@ -159,7 +159,7 @@
             if ($PSBoundParameters.ContainsKey('Height')) {
                 if ($Range -is [OfficeOpenXml.ExcelRow]   ) {$Range.Height = $Height }
                 elseif ($Range -is [OfficeOpenXml.ExcelRange] ) {
-                    ($Range.Start.Row)..($Range.Start.Row + $Range.Rows) |
+                    ($Range.Start.Row)..($Range.Start.Row + $Range.Rows - 1) |
                         ForEach-Object {$Range.Worksheet.Row($_).Height = $Height }
                 }
                 else {Write-Warning -Message ("Can set the height of a row or a range but not a {0} object" -f ($Range.GetType().name)) }

--- a/__tests__/Export-Excel.Tests.ps1
+++ b/__tests__/Export-Excel.Tests.ps1
@@ -767,6 +767,11 @@ Describe ExportExcel -Tag "ExportExcel" {
             else { $sheet.Column(1) | Set-ExcelRange -Bold }
             $sheet.Column(2) | Set-ExcelRange -Width 29 -WrapText
             $sheet.Column(3) | Set-ExcelRange -HorizontalAlignment Right -NFormat "#,###"
+
+            # Issue 1350: Set-ExcelRow -height bleeds into next row when using
+            # Set-ExcelRow uses a Range object to call Set-ExcelRange instead of just the row
+            Set-ExcelRange -Range (New-Object -TypeName OfficeOpenXml.ExcelAddress @(1, $sheet.Dimension.Start.Column, 1, $sheet.Dimension.End.Column)) -Height 25 -Worksheet $sheet
+
             Set-ExcelRange -Address $sheet.Cells["E1:H1048576"]  -HorizontalAlignment Right -NFormat "#,###"
             Set-ExcelRange -Address $sheet.Column(4)  -HorizontalAlignment Right -NFormat "#,##0.0" -Bold
             Set-ExcelRange -Address $sheet.Row(1) -Bold -HorizontalAlignment Center
@@ -798,6 +803,8 @@ Describe ExportExcel -Tag "ExportExcel" {
             $sheet.Column(2).width                                      | Should      -Be  29
             $sheet.Column(3).style.horizontalalignment                  | Should      -Be  'right'
             $sheet.Column(4).style.horizontalalignment                  | Should      -Be  'right'
+            $sheet.Row(1).height                                        | Should      -Be 25
+            $sheet.Row(2).height                                        | Should -Not -Be 25
             $sheet.Cells["A1"].Style.HorizontalAlignment                | Should      -Be  'Center'
             $sheet.Cells['E2'].Style.HorizontalAlignment                | Should      -Be  'right'
             $sheet.Cells['A1'].Style.Font.Bold                          | Should      -Be  $true


### PR DESCRIPTION
As described by @mscreations: 

```powershell
if ($Title) {
    $ws.View.FreezePanes(2, 1)
    Write-Verbose -Message "Froze title and header rows"
}
```

Should be 

```powershell
if ($Title) {
    $ws.View.FreezePanes(3, 1)
    Write-Verbose -Message "Froze title and header rows"
}
```

FreezetopRowFirstColumn does the same for freezing the top row with a title:

```powershell
#Allow single switch or two seperate ones.
if ($FreezeTopRowFirstColumn -or ($FreezeTopRow -and $FreezeFirstColumn)) {
    if ($Title) {
        $ws.View.FreezePanes(3, 2) ### THIS LINE RIGHT HERE AS EXAMPLE
        Write-Verbose -Message "Froze title and header rows and first column"
    }
    else {
        $ws.View.FreezePanes(2, 2)
        Write-Verbose -Message "Froze top row and first column"
    }
}
elseif ($FreezeTopRow) {
    if ($Title) {
        $ws.View.FreezePanes(3, 1) ### THIS LINE RIGHT HERE WHAT NEEDED TO BE FIXED
        Write-Verbose -Message "Froze title and header rows"
    }
    else {
        $ws.View.FreezePanes(2, 1)
        Write-Verbose -Message "Froze top row"
    }
}
```

Fixes issue #1344 