### PR TITLE
Fix Issue 1344 with Freeze Top Row

### DIFF
--- a/Public/Export-Excel.ps1
+++ b/Public/Export-Excel.ps1
@@ -494,7 +494,7 @@
             }
             elseif ($FreezeTopRow) {
                 if ($Title) {
-                    $ws.View.FreezePanes(2, 1)
+                    $ws.View.FreezePanes(3, 1)
                     Write-Verbose -Message "Froze title and header rows"
                 }
                 else {


### PR DESCRIPTION
As described by @mscreations: 

```powershell
if ($Title) {
    $ws.View.FreezePanes(2, 1)
    Write-Verbose -Message "Froze title and header rows"
}
```

Should be 

```powershell
if ($Title) {
    $ws.View.FreezePanes(3, 1)
    Write-Verbose -Message "Froze title and header rows"
}
```

FreezetopRowFirstColumn does the same for freezing the top row with a title:

```powershell
#Allow single switch or two seperate ones.
if ($FreezeTopRowFirstColumn -or ($FreezeTopRow -and $FreezeFirstColumn)) {
    if ($Title) {
        $ws.View.FreezePanes(3, 2) ### THIS LINE RIGHT HERE AS EXAMPLE
        Write-Verbose -Message "Froze title and header rows and first column"
    }
    else {
        $ws.View.FreezePanes(2, 2)
        Write-Verbose -Message "Froze top row and first column"
    }
}
elseif ($FreezeTopRow) {
    if ($Title) {
        $ws.View.FreezePanes(3, 1) ### THIS LINE RIGHT HERE WHAT NEEDED TO BE FIXED
        Write-Verbose -Message "Froze title and header rows"
    }
    else {
        $ws.View.FreezePanes(2, 1)
        Write-Verbose -Message "Froze top row"
    }
}
```

Fixes issue #1344 