### PR TITLE
Add missing parameter aliases to align with caller/callee

### DIFF
--- a/ImportExcel.psd1
+++ b/ImportExcel.psd1
@@ -6,7 +6,7 @@
     RootModule         = 'ImportExcel.psm1'
 
     # Version number of this module.
-    ModuleVersion      = '7.8.5'
+    ModuleVersion      = '7.8.6'
 
     # ID used to uniquely identify this module
     GUID               = '60dd4136-feff-401a-ba27-a84458c57ede'

--- a/Public/ConvertFrom-ExcelData.ps1
+++ b/Public/ConvertFrom-ExcelData.ps1
@@ -8,7 +8,8 @@ function ConvertFrom-ExcelData {
         [ScriptBlock]$ScriptBlock,
         [Alias("Sheet")]
         $WorksheetName = 1,
-        [int]$HeaderRow = 1,
+		[Alias('HeaderRow', 'TopRow')]
+        [int]$StartRow = 1,
         [string[]]$Header,
         [switch]$NoHeader,
         [switch]$DataOnly

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+# 7.8.6
+
+- Thank you [John Boyne](https://github.com/kyllath)
+    - Add missing parameter aliases to align with caller/callee
+
 # 7.8.5
 
 - Added `Get-ExcelFileSchema` to get the schema of an Excel file.


### PR DESCRIPTION
Fix issue where none of 'HeaderRow', 'TopRow' and 'StartRow' work in ConvertFrom-ExcelToSQLInsert, preventing you from skipping rows.

Issue is that aliases are missing from the parameter list of ConvertFrom-ExcelData. 
ConvertFrom-ExcelToSQLInsert accepts 'HeaderRow', 'TopRow' and 'StartRow', but passes 'StartRow', while  ConvertFrom-ExcelData only accepts 'HeaderRow'

FIX: Alter ConvertFrom-ExcelData to have the same aliases for the parameter as both its caller, ConvertFrom-ExcelToSQLInsert and its callee, Import-Excel. All three now have:
        [Alias('HeaderRow', 'TopRow')]
        [Int]$StartRow = 1,