### PR TITLE
[Import-Excel] Don't request ReadWrite access to the file

### DIFF
--- a/Public/Import-Excel.ps1
+++ b/Public/Import-Excel.ps1
@@ -119,7 +119,7 @@
                     throw "'$($Path)' file not found"
                 }
 
-                $stream = New-Object -TypeName System.IO.FileStream -ArgumentList $Path, 'Open', 'Read', 'ReadWrite'
+                $stream = New-Object -TypeName System.IO.FileStream -ArgumentList $Path, 'Open', 'Read'
                 $ExcelPackage = New-Object -TypeName OfficeOpenXml.ExcelPackage
                 if ($Password) { $ExcelPackage.Load($stream, $Password) }
                 else { $ExcelPackage.Load($stream) }


### PR DESCRIPTION
Write access can cause locking issues, and I don't think it is really needed for this cmdlet.

Tested this locally and it works