### PR TITLE
[ConvertTo-ExcelXlsx] open XLS as read-only

### DIFF
--- a/Public/ConvertTo-ExcelXlsx.ps1
+++ b/Public/ConvertTo-ExcelXlsx.ps1
@@ -46,7 +46,7 @@ function ConvertTo-ExcelXlsx {
         }
 
         $Excel.Visible = $false
-        $null = $Excel.Workbooks.Open($xlsFile.FullName)
+        $null = $Excel.Workbooks.Open($xlsFile.FullName, $null, $true)
         $Excel.ActiveWorkbook.SaveAs($xlsxPath, $xlFixedFormat)
         $Excel.ActiveWorkbook.Close()
         $Excel.Quit()

--- a/Public/ConvertTo-ExcelXlsx.ps1
+++ b/Public/ConvertTo-ExcelXlsx.ps1
@@ -45,11 +45,15 @@ function ConvertTo-ExcelXlsx {
             throw "Could not create Excel.Application ComObject. Please verify that Excel is installed."
         }
 
-        $Excel.Visible = $false
-        $null = $Excel.Workbooks.Open($xlsFile.FullName, $null, $true)
-        $Excel.ActiveWorkbook.SaveAs($xlsxPath, $xlFixedFormat)
-        $Excel.ActiveWorkbook.Close()
-        $Excel.Quit()
+        try {  
+            $Excel.Visible = $false
+            $null = $Excel.Workbooks.Open($xlsFile.FullName, $null, $true)
+            $Excel.ActiveWorkbook.SaveAs($xlsxPath, $xlFixedFormat)
+        }
+        finally {
+            $Excel.ActiveWorkbook.Close()
+            $Excel.Quit()
+        }
     }
 }
 

--- a/Public/ConvertTo-ExcelXlsx.ps1
+++ b/Public/ConvertTo-ExcelXlsx.ps1
@@ -51,7 +51,10 @@ function ConvertTo-ExcelXlsx {
             $Excel.ActiveWorkbook.SaveAs($xlsxPath, $xlFixedFormat)
         }
         finally {
-            $Excel.ActiveWorkbook.Close()
+            if ($null -ne $Excel.ActiveWorkbook) {
+                $Excel.ActiveWorkbook.Close()
+            }
+            
             $Excel.Quit()
         }
     }


### PR DESCRIPTION
This could help prevent file locking issues. Also put everything in a try-finally to be extra sure that it will quit.

Just some extra guardrails.

see also: https://learn.microsoft.com/en-US/dotnet/api/microsoft.office.interop.excel.workbooks.open

I tested this locally and it works