### PR TITLE
[ConvertTo-ExcelXlsx] Accept a collection of paths

### DIFF
--- a/Public/ConvertTo-ExcelXlsx.ps1
+++ b/Public/ConvertTo-ExcelXlsx.ps1
@@ -47,12 +47,16 @@ function ConvertTo-ExcelXlsx {
 
         try {  
             $Excel.Visible = $false
-            $null = $Excel.Workbooks.Open($xlsFile.FullName, $null, $true)
-            $Excel.ActiveWorkbook.SaveAs($xlsxPath, $xlFixedFormat)
+            $workbook = $Excel.Workbooks.Open($xlsFile.FullName, $null, $true)
+            if ($null -eq $workbook) {
+                Write-Host "Failed to open workbook"
+            } else {
+                $workbook.SaveAs($xlsxPath, $xlFixedFormat)
+            }
         }
         finally {
-            if ($null -ne $Excel.ActiveWorkbook) {
-                $Excel.ActiveWorkbook.Close()
+            if ($null -ne $workbook) {
+                $workbook.Close()
             }
             
             $Excel.Quit()

--- a/Public/ConvertTo-ExcelXlsx.ps1
+++ b/Public/ConvertTo-ExcelXlsx.ps1
@@ -19,7 +19,7 @@ function ConvertTo-ExcelXlsx {
 
                 $xlFixedFormat = 51 #Constant for XLSX Workbook
                 $xlsFile = Get-Item -Path $singlePath
-                $xlsxPath = "{0}x" -f $xlsFile.FullName
+                $xlsxPath = [System.IO.Path]::ChangeExtension($xlsFile.FullName, ".xlsx")
 
                 if ($xlsFile.Extension -ne ".xls") {
                     throw "Expected .xls extension"

--- a/Public/ConvertTo-ExcelXlsx.ps1
+++ b/Public/ConvertTo-ExcelXlsx.ps1
@@ -3,64 +3,81 @@ function ConvertTo-ExcelXlsx {
     param
     (
         [parameter(Mandatory = $true, ValueFromPipeline)]
-        [string]$Path,
+        [string[]]$Path,
         [parameter(Mandatory = $false)]
         [switch]$Force
     )
     process {
-        if (-Not ($Path | Test-Path) ) {
-            throw "File not found"
-        }
-        if (-Not ($Path | Test-Path -PathType Leaf) ) {
-            throw "Folder paths are not allowed"
-        }
+        try {
+            foreach ($singlePath in $Path) {
+                if (-Not ($singlePath | Test-Path) ) {
+                    throw "File not found"
+                }
+                if (-Not ($singlePath | Test-Path -PathType Leaf) ) {
+                    throw "Folder paths are not allowed"
+                }
 
-        $xlFixedFormat = 51 #Constant for XLSX Workbook
-        $xlsFile = Get-Item -Path $Path
-        $xlsxPath = "{0}x" -f $xlsFile.FullName
+                $xlFixedFormat = 51 #Constant for XLSX Workbook
+                $xlsFile = Get-Item -Path $singlePath
+                $xlsxPath = "{0}x" -f $xlsFile.FullName
 
-        if ($xlsFile.Extension -ne ".xls") {
-            throw "Expected .xls extension"
-        }
+                if ($xlsFile.Extension -ne ".xls") {
+                    throw "Expected .xls extension"
+                }
 
-        if (Test-Path -Path $xlsxPath) {
-            if ($Force) {
-                try {
-                    Remove-Item $xlsxPath -Force
+                if (Test-Path -Path $xlsxPath) {
+                    if ($Force) {
+                        try {
+                            Remove-Item $xlsxPath -Force
+                        }
+                        catch {
+                            throw "{0} already exists and cannot be removed. The file may be locked by another application." -f $xlsxPath
+                        }
+                        Write-Verbose $("Removed {0}" -f $xlsxPath)
+                    }
+                    else {
+                        throw "{0} already exists!" -f $xlsxPath
+                    }
+                }
+
+                if ($null -eq $Excel)
+                {
+                    try {
+                        $Excel = New-Object -ComObject "Excel.Application"
+                    }
+                    catch {
+                        throw "Could not create Excel.Application ComObject. Please verify that Excel is installed."
+                    }
+                }
+
+                try {  
+                    $Excel.Visible = $false
+                    $workbook = $Excel.Workbooks.Open($xlsFile.FullName, $null, $true)
+                    if ($null -eq $workbook) {
+                        Write-Host "Failed to open workbook"
+                    } else {
+                        $workbook.SaveAs($xlsxPath, $xlFixedFormat)
+                    }
                 }
                 catch {
-                    throw "{0} already exists and cannot be removed. The file may be locked by another application." -f $xlsxPath
+                    Write-Error ("Failed to convert {0} to XLSX." -f $xlsFile.FullName)
+                    throw
                 }
-                Write-Verbose $("Removed {0}" -f $xlsxPath)
-            }
-            else {
-                throw "{0} already exists!" -f $xlsxPath
-            }
-        }
-
-        try {
-            $Excel = New-Object -ComObject "Excel.Application"
-        }
-        catch {
-            throw "Could not create Excel.Application ComObject. Please verify that Excel is installed."
-        }
-
-        try {  
-            $Excel.Visible = $false
-            $workbook = $Excel.Workbooks.Open($xlsFile.FullName, $null, $true)
-            if ($null -eq $workbook) {
-                Write-Host "Failed to open workbook"
-            } else {
-                $workbook.SaveAs($xlsxPath, $xlFixedFormat)
+                finally {
+                    if ($null -ne $workbook) {
+                        $workbook.Close()
+                        [System.Runtime.InteropServices.Marshal]::ReleaseComObject($workbook) | Out-Null
+                        $workbook = $null
+                    }
+                }
             }
         }
         finally {
-            if ($null -ne $workbook) {
-                $workbook.Close()
+            if ($null -ne $Excel) {
+                $Excel.Quit()
+                [System.Runtime.InteropServices.Marshal]::ReleaseComObject($Excel) | Out-Null
+                $Excel = $null
             }
-            
-            $Excel.Quit()
         }
     }
 }
-

--- a/Public/ConvertTo-ExcelXlsx.ps1
+++ b/Public/ConvertTo-ExcelXlsx.ps1
@@ -83,7 +83,7 @@ function ConvertTo-ExcelXlsx {
                     }
                 }
                 catch {
-                    Write-Error ("Failed to convert {0} to XLSX." -f $xlsFile.FullName)
+                    Write-Error ("Failed to convert {0} to XLSX. To avoid network issues or locking issues, you could try the -CacheToTemp parameter." -f $xlsFile.FullName)
                     throw
                 }
                 finally {

--- a/Public/ConvertTo-ExcelXlsx.ps1
+++ b/Public/ConvertTo-ExcelXlsx.ps1
@@ -7,7 +7,9 @@ function ConvertTo-ExcelXlsx {
         [parameter(Mandatory = $false)]
         [switch]$Force,
         [parameter(Mandatory = $false)]
-        [switch]$CacheToTemp
+        [switch]$CacheToTemp,
+        [parameter(Mandatory = $false)]
+        [string]$CacheDirectory
     )
     process {
         try {
@@ -53,7 +55,11 @@ function ConvertTo-ExcelXlsx {
                 }
 
                 if ($CacheToTemp) {
-                    $tempPath = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetFileName($xlsFile.FullName))
+                    if (-not $CacheDirectory) {
+                        $CacheDirectory = [System.IO.Path]::GetTempPath()
+                    }
+                    $tempPath = [System.IO.Path]::Combine($CacheDirectory, [System.IO.Path]::GetFileName($xlsFile.FullName))
+                    Write-Host ("Using Temp path: {0}" -f $tempPath)
                     Copy-Item -Path $xlsFile.FullName -Destination $tempPath -Force
                     $fileToProcess = $tempPath
                 }


### PR DESCRIPTION
If I loop through a big list of XLS files that I want to convert, it can throw an error at some point in the list:

```
Unable to get the SaveAs property of the Workbook class
```

This could be because of either file locking or issues performing round-trips to network locations. In a situation with network paths, it will make two full roundtrips per path entirely via Excel interop. And that could be a very error-prone situation. When converting the same list of files repeatedly, I was seeing it fail randomly each time on different files in that same list.

The changes in this PR:

1. This allows you to loop over a collection of paths that you want to convert, while only needing to create one COM object.

    - This is noticeably faster. Processing a dozen items for me goes from 2 minutes to 1 minute.

2. The $workbook object created by the Open method is used directly, instead of relying on the stateful ActiveWorkbook property of the $Excel object.

3. This optionally allows caching a copy of each file to the local Temp directory first, which can avoid both locking and network roundtrips. I made the CacheDirectory configurable as well, to handle the case where the default Temp directory isn't writeable. The default behavior is the same as before.

4. It also just uses ChangeExtension to set the extension since that will work a little better overall in cross-platform scenarios with different case sensitivity.
