### PR TITLE
Add NoFormulaConversion to Export-Excel

### DIFF
--- a/Examples/NoFormulaConversion/NoFormula-AllColumns.ps1
+++ b/Examples/NoFormulaConversion/NoFormula-AllColumns.ps1
@@ -1,0 +1,13 @@
+try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
+
+$xlSourcefile = "$env:TEMP\NoFormulaExample.xlsx"
+
+#Remove existing file
+Remove-Item $xlSourcefile -ErrorAction Ignore
+
+#These formulas should not calculate and remain as text
+[PSCustOmobject][Ordered]@{   
+    Formula1 = "=COUNT(1,1,1)"
+    Formula2 = "=SUM(2,3)"
+    Formula3 = "=1=1"
+} | Export-Excel $xlSourcefile -NoFormulaConversion * -Calculate -Show

--- a/Examples/NoFormulaConversion/NoFormula-NamedColumns.ps1
+++ b/Examples/NoFormulaConversion/NoFormula-NamedColumns.ps1
@@ -1,0 +1,12 @@
+try {Import-Module $PSScriptRoot\..\..\ImportExcel.psd1} catch {throw ; return}
+
+$xlSourcefile = "$env:TEMP\NoFormulaExample.xlsx"
+
+#Remove existing file
+Remove-Item $xlSourcefile -ErrorAction Ignore
+
+#Simulate a matching comparison to get a SideIndicator of '=='
+$comparison = Compare-Object -ReferenceObject @(1) -DifferenceObject @(1) -IncludeEqual
+
+#Add '-NoFormulaConversion SideIndicator' to allow '==' to be used in the SideIndicator column without converting to a formula
+$comparison | Export-Excel $xlSourcefile -NoFormulaConversion SideIndicator -Show

--- a/Public/Export-Excel.ps1
+++ b/Public/Export-Excel.ps1
@@ -80,6 +80,7 @@
         [Switch]$DisplayPropertySet,
         [String[]]$NoNumberConversion,
         [String[]]$NoHyperLinkConversion,
+        [String[]]$NoFormulaConversion,
         [Object[]]$ConditionalFormat,
         [Object[]]$ConditionalText,
         [Object[]]$Style,
@@ -330,7 +331,10 @@
                                 #Other objects or null.
                                 if ($null -ne $v) { $ws.Cells[$row, $ColumnIndex].Value = $v.toString() }
                             }
-                            elseif ($v[0] -eq '=') {
+                            elseif ( $v[0] -eq '=' -and
+                                $NoFormulaConversion -ne '*' -and
+                                $NoFormulaConversion -notcontains $Name
+                            ) {
                                 $ws.Cells[$row, $ColumnIndex].Formula = ($v -replace '^=', '')
                                 if ($setNumformat) { $ws.Cells[$row, $ColumnIndex].Style.Numberformat.Format = $Numberformat }
                             }

--- a/__tests__/Export-Excel.Tests.ps1
+++ b/__tests__/Export-Excel.Tests.ps1
@@ -255,7 +255,7 @@ Describe ExportExcel -Tag "ExportExcel" {
         }
         it "Created the worksheet with the expected name, number of rows and number of columns     " {
             $ws.Name                                                    | Should      -Be "sheet1"
-            $ws.Dimension.Columns                                       | Should      -Be  28
+            $ws.Dimension.Columns                                       | Should      -Be  29
             $ws.Dimension.Rows                                          | Should      -Be  2
         }
         it "Set a date     in Cell A2                                                              " {
@@ -330,7 +330,7 @@ Describe ExportExcel -Tag "ExportExcel" {
         it "Creates no formula in cell AC2 NotAFormula (NoFormulaConversion)                        " {
             $ws.Cells[2, 29].Value                                     | Should      -Be  '=SUM(2,3)'
             $ws.Cells[2, 29].Value.GetType().name                      | Should      -Be  'String'
-            $ws.Cells[2, 29].Formula                                   | Should      -Be  [string]::Empty
+            $ws.Cells[2, 29].Formula                                   | Should      -Be  ''
         }
     }
 


### PR DESCRIPTION
This feature will allow formulas to be 'disabled' when using Export-Excel by treating the values as text.

This is especially useful when your data contains cells that may start with =, such as a Compare-Object output, without having to reformat the data. E.g. "equals". (#1459)

I've kept the naming convention and functionality similar to the existing 'overrides'. (NoNumberConversion and NoHyperLinkConversion)
