### PR TITLE
6v4tq8mhl o23a performance fix

### DIFF
--- a/Public/Import-Excel.ps1
+++ b/Public/Import-Excel.ps1
@@ -217,7 +217,7 @@
                         else { $TextColRegEx = $null }
 						
                         foreach ($R in $rows) {
-							$NewRow = [Ordered]@{ }
+			$NewRow = [Ordered]@{ }
                             #Disabled write-verbose for speed
                             #  Write-Verbose "Import row '$R'"
                             if ($TextColRegEx) {
@@ -234,22 +234,20 @@
                             }
                             else {
                                 foreach ($P in $PropertyNames) {
-									
+			
                                     $newRow.Add(($P.Value),($sheet.Cells[$R, $P.Column].Value))
 									
-                                    #    Write-Verbose "Import cell '$($Worksheet.Cells[$R, $P.Column].Address)' with property name '$($p.Value)' and value '$($Worksheet.Cells[$R, $P.Column].Value)'."
+                                    #Write-Verbose "Import cell '$($Worksheet.Cells[$R, $P.Column].Address)' with property name '$($p.Value)' 
+				    #and value '$($Worksheet.Cells[$R, $P.Column].Value)'."
                                 }
                             }
-							# Add to a generic list first to minimize the number of additions to $xlbook,
-							# as frequent direct additions do not scale well and can degrade performance.
-
-							$TempList_GenericList.Add([PSCustomObject]$NewRow)
-							
-							
-							}
-						$xlBook["$targetSheetname"] += $TempList_GenericList.ToArray()
+				# Add to a generic list first to minimize the number of additions to $xlbook,
+				# as frequent direct additions do not scale well and can degrade performance.
+				$TempList_GenericList.Add([PSCustomObject]$NewRow)		
+			}
+				$xlBook["$targetSheetname"] += $TempList_GenericList.ToArray()
                         #endregion
-						}
+			}
                 }
             }
             catch { throw "Failed importing the Excel workbook '$Path' with worksheet '$WorksheetName': $_"; return }

--- a/Public/Import-Excel.ps1
+++ b/Public/Import-Excel.ps1
@@ -193,8 +193,8 @@
                         Write-Warning "Worksheet '$WorksheetName' in workbook '$Path' contains no data in the rows after top row '$StartRow'"
                     }
                     else {
-						# Create a generic list to collect rows before adding them in bulk.
-						$TempList_GenericList = New-Object System.Collections.Generic.List[System.Object]
+			# Create a generic list to collect rows before adding them in bulk.
+			$TempList_GenericList = New-Object System.Collections.Generic.List[System.Object]
                         #region Create one object per row
                         if ($AsText -or $AsDate) {
                             <#join items in AsText together with ~~~ . Escape any regex special characters...
@@ -229,20 +229,25 @@
                                     elseif ($MatchTest.groups.name -eq "asdate" -and $sheet.Cells[$R, $P.Column].Value -is [System.ValueType]) {
                                         $NewRow[$P.Value] = [datetime]::FromOADate(($sheet.Cells[$R, $P.Column].Value))
                                     }
-                                    else { $NewRow[$P.Value] = $sheet.Cells[$R, $P.Column].Value }
-                                }
+                                    else { 
+				    	$NewRow[$P.Value] = $sheet.Cells[$R, $P.Column].Value 
+				    }
+
+				    $TempList_GenericList.Add([PSCustomObject]$NewRow)	
+                                    }
                             }
                             else {
                                 foreach ($P in $PropertyNames) {
 			
                                     $newRow.Add(($P.Value),($sheet.Cells[$R, $P.Column].Value))
-									
-                                    #Write-Verbose "Import cell '$($Worksheet.Cells[$R, $P.Column].Address)' with property name '$($p.Value)' 
+							
+                                    #Write-Verbose "Import cell '$($Worksheet.Cells[$R, $P.Column].Address)' 
+				    #with property name '$($p.Value)' 
 				    #and value '$($Worksheet.Cells[$R, $P.Column].Value)'."
                                 }
                             }
 				# Add to a generic list first to minimize the number of additions to $xlbook,
-				# as frequent direct additions do not scale well and can degrade performance.
+				#as frequent direct additions do not scale well and can degrade performance.
 				$TempList_GenericList.Add([PSCustomObject]$NewRow)		
 			}
 				$xlBook["$targetSheetname"] += $TempList_GenericList.ToArray()


### PR DESCRIPTION
Hey,

I've encountered a significant performance issue with the Import-Excel function when processing large .xlsx files. The problem lies in the way rows are added to $xlbook["$targetSheetname"] using the += operator.

The += operator in PowerShell creates a new array each time it's used, copying over all existing elements along with the new one. This results in exponential performance degradation as the number of rows increases, because PowerShell arrays are fixed-size.

My example test file:

![grafik](https://github.com/user-attachments/assets/e66d3ecc-a3ff-4f0c-ae89-6e434dae5008)

Changes in PR:

Their is probably a more proper way to fix this but the "low" effort route without changing to much would be to create a New-Generic List -> Add each row to it and after we are done add it to $xlbook. With that we minimze the times we need to recreate $xlbook.

I measured the performance afterwards and got the following results:

Without fixes:

20k Rows

Seconds           : 5
Milliseconds      : 621


40k Rows

Seconds           : 19
Milliseconds      : 282

60k Rows

Seconds           : 41
Milliseconds      : 205

80k Rows

Minutes           : 1
Seconds           : 22
Milliseconds      : 897

With the Fixes:

20k Rows

Seconds           : 6
Milliseconds      : 215

40k Rows

Seconds           : 8
Milliseconds      : 429

60k Rows

Seconds           : 12
Milliseconds      : 747

80k Rows

Seconds           : 16
Milliseconds      : 541


Sorry if I did miss something as this is my first pull request. Let me know what you think of it or if there is a better way to do this.