### PR TITLE
Fix Set-ExcelRange -Height changing the height of the row after the range

### DIFF
--- a/Public/Set-ExcelRange.ps1
+++ b/Public/Set-ExcelRange.ps1
@@ -159,7 +159,7 @@
             if ($PSBoundParameters.ContainsKey('Height')) {
                 if ($Range -is [OfficeOpenXml.ExcelRow]   ) {$Range.Height = $Height }
                 elseif ($Range -is [OfficeOpenXml.ExcelRange] ) {
-                    ($Range.Start.Row)..($Range.Start.Row + $Range.Rows) |
+                    ($Range.Start.Row)..($Range.Start.Row + $Range.Rows - 1) |
                         ForEach-Object {$Range.Worksheet.Row($_).Height = $Height }
                 }
                 else {Write-Warning -Message ("Can set the height of a row or a range but not a {0} object" -f ($Range.GetType().name)) }

--- a/__tests__/Set-Row_Set-Column-SetFormat.tests.ps1
+++ b/__tests__/Set-Row_Set-Column-SetFormat.tests.ps1
@@ -1,4 +1,4 @@
-﻿
+﻿Import-Module $PSScriptRoot\..\ImportExcel.psd1 -Force
 
 Describe "Number format expansion and setting" {
     BeforeAll {
@@ -231,6 +231,43 @@ Describe "Set-ExcelColumn, Set-ExcelRow and Set-ExcelRange"  {
             $ws.Cells["e7"].Style.Fill.BackgroundColor.Rgb              | Should      -Be "FFF0F8FF"
             $ws.Cells["e7"].Style.Fill.PatternColor.Rgb                 | Should      -Be "FFFF0000"
             $ws.Cells["e7"].Style.Fill.PatternType                      | Should      -Be "DarkTrellis"
+        }
+    }
+
+    Context "Row height setting - Issue #1738" {
+        BeforeAll {
+            $heightPath = "TestDrive:\testHeight.xlsx"
+            Remove-Item -Path $heightPath -ErrorAction SilentlyContinue
+            $heightData = ConvertFrom-Csv -InputObject @"
+            A,B,C
+            1,2,3
+            4,5,6
+            7,8,9
+            10,11,12
+            13,14,15
+            16,17,18
+"@
+            $heightExcel = $heightData | Export-Excel -Path $heightPath -WorksheetName TestHeight -PassThru
+            $heightWs = $heightExcel.Workbook.Worksheets["TestHeight"]
+            $defaultHeight = $heightWs.DefaultRowHeight
+            Set-ExcelRow   -Worksheet $heightWs -Row 1     -Height 42
+            Set-ExcelRange -Worksheet $heightWs -Range '4:5' -Height 32
+        }
+        AfterAll {
+            Close-ExcelPackage -ExcelPackage $heightExcel -NoSave
+        }
+        it "Set the height of the single row given to Set-ExcelRow                                 " {
+            $heightWs.Row(1).Height                                     | Should      -Be 42
+        }
+        it "Set the height of each row in the range given to Set-ExcelRange                        " {
+            $heightWs.Row(4).Height                                     | Should      -Be 32
+            $heightWs.Row(5).Height                                     | Should      -Be 32
+        }
+        it "Did not change the height of the rows after those specified                            " {
+            $heightWs.Row(2).Height                                     | Should      -Be $defaultHeight
+            $heightWs.Row(3).Height                                     | Should      -Be $defaultHeight
+            $heightWs.Row(6).Height                                     | Should      -Be $defaultHeight
+            $heightWs.Row(7).Height                                     | Should      -Be $defaultHeight
         }
     }
 


### PR DESCRIPTION
Fixes #1738

## Problem

`Set-ExcelRange -Height` (and `Set-ExcelRow -Height`, which delegates to it) also changed the height of the first row *after* the requested range. From the issue's repro, setting row 1 to 42 and rows 4:5 to 32 produced:

```
42, 42, 15, 32, 32, 32, 15   # rows 2 and 6 wrongly modified
```

## Cause

An off-by-one in the row loop in `Set-ExcelRange`. EPPlus's `ExcelRange.Rows` is a row *count* (`End.Row - Start.Row + 1`), so

```powershell
($Range.Start.Row)..($Range.Start.Row + $Range.Rows)
```

iterates one row past the end of the range (a 1-row range loops `N..N+1`). The equivalent `-Width` logic for columns already subtracts 1, which is why `Set-ExcelColumn -Width` was unaffected.

## Fix

Subtract 1, matching the `-Width` branch:

```powershell
($Range.Start.Row)..($Range.Start.Row + $Range.Rows - 1)
```

The issue's repro now produces `42, 15, 15, 32, 32, 15, 15` as expected. As a side effect this also fixes a crash when the range ends at the worksheet's last possible row (the old code called `.Row(1048577)`, which throws).

## Tests

Added a regression context to `Set-Row_Set-Column-SetFormat.tests.ps1` covering `Set-ExcelRow` on a single row and `Set-ExcelRange` on a multi-row range, asserting the neighbouring rows keep the default height. The new tests fail against the unfixed code ("Expected 15, but got 42") and pass with the fix. Also added the same `Import-Module $PSScriptRoot\..\ImportExcel.psd1 -Force` line used by sibling test files so this file tests the repo code when run standalone.

Verified on Windows PowerShell 5.1 and PowerShell 7; full test file passes (22/22).

🤖 Generated with [Claude Code](https://claude.com/claude-code)