### PR TITLE
Make the CI pipeline work with Pester 5 and later

### DIFF
--- a/CI/CI.ps1
+++ b/CI/CI.ps1
@@ -100,22 +100,47 @@ if (-not $VersionFilePath) {
     '[Progress] Installing Module.'
     . .\CI\Install.ps1
     '[Progress] Invoking Pester.'
-    $pesterParams = @{
-        OutputFile = ('TestResultsPS{0}.xml' -f $PSVersionTable.PSVersion)
-        PassThru = $true
-    }
-    if ($TestImportOnly) {
-        $pesterParams['Tag'] = 'TestImportOnly'
+    $resultsFileName = 'TestResultsPS{0}.xml' -f $PSVersionTable.PSVersion
+    if (Get-Command -Name New-PesterConfiguration -ErrorAction SilentlyContinue) {
+        # Pester 5 and later. -OutputFile/-Tag/-ExcludeTag were replaced by the configuration object;
+        # the default TestResult format is NUnit 2.5, which is what PublishTestResults expects.
+        $pesterConfig = New-PesterConfiguration
+        $pesterConfig.Run.PassThru          = $true
+        $pesterConfig.TestResult.Enabled    = $true
+        $pesterConfig.TestResult.OutputPath = $resultsFileName
+        if ($TestImportOnly) {
+            $pesterConfig.Filter.Tag        = 'TestImportOnly'
+        }
+        else {
+            $pesterConfig.Filter.ExcludeTag = 'TestImportOnly'
+        }
+        $testResults = Invoke-Pester -Configuration $pesterConfig
+        'Pester invocation complete!'
+        if ($testResults.FailedCount -gt 0) {
+            "Test failures:"
+            $testResults.Failed | Format-List -Property ExpandedPath, ErrorRecord
+            Write-Error "$($testResults.FailedCount) Pester tests failed. Build cannot continue!"
+        }
     }
     else {
-        $pesterParams['ExcludeTag'] = 'TestImportOnly'
-    }
-    $testResults = Invoke-Pester @pesterParams
-    'Pester invocation complete!'
-    if ($testResults.FailedCount -gt 0) {
-        "Test failures:"
-        $testResults.TestResult | Where-Object {-not $_.Passed} | Format-List
-        Write-Error "$($testResults.FailedCount) Pester tests failed. Build cannot continue!"
+        # Pester 4 and earlier.
+        $pesterParams = @{
+            OutputFile = $resultsFileName
+            PassThru = $true
+        }
+        if ($TestImportOnly) {
+            $pesterParams['Tag'] = 'TestImportOnly'
+        }
+        else {
+            $pesterParams['ExcludeTag'] = 'TestImportOnly'
+        }
+        $testResults = Invoke-Pester @pesterParams
+        'Pester invocation complete!'
+        if ($testResults.FailedCount -gt 0) {
+            "Test failures:"
+            $testResults.TestResult | Where-Object {-not $_.Passed} | Format-List
+            Write-Error "$($testResults.FailedCount) Pester tests failed. Build cannot continue!"
+        }
     }
 }
 if ($Finalize) {

--- a/__tests__/Compare-WorkSheet.tests.ps1
+++ b/__tests__/Compare-WorkSheet.tests.ps1
@@ -66,11 +66,12 @@ Describe "Compare Worksheet" {
                 $null = Compare-Worksheet "TestDrive:\server1.xlsx" "TestDrive:\server2.xlsx" -BackgroundColor ([System.Drawing.Color]::LightGreen)
             }
             else {
-                $cmdline = 'Import-Module {0}; $null = Compare-WorkSheet "{1}" "{2}" -BackgroundColor ([System.Drawing.Color]::LightGreen) -GridView; Start-Sleep -sec 5; exit'
+                $cmdline = 'Import-Module "{0}"; $null = Compare-WorkSheet "{1}" "{2}" -BackgroundColor ([System.Drawing.Color]::LightGreen) -GridView; Start-Sleep -sec 5; exit'
                 $cmdline = $cmdline -f  (Resolve-Path "$PSScriptRoot\..\importExcel.psd1" ) ,
                                         (Join-Path (Get-PSDrive TestDrive).root "server1.xlsx"),
                                         (Join-Path (Get-PSDrive TestDrive).root "server2.xlsx")
-                powershell.exe -Command  $cmdline
+                #-EncodedCommand, because -Command mangles the embedded quotes, breaking the import when the module path contains spaces
+                powershell.exe -EncodedCommand ([Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($cmdline)))
             }
             $xl1  = Open-ExcelPackage -Path "TestDrive:\server1.xlsx"
             $xl2  = Open-ExcelPackage -Path "TestDrive:\server2.xlsx"

--- a/__tests__/Export-Excel.Tests.ps1
+++ b/__tests__/Export-Excel.Tests.ps1
@@ -528,7 +528,7 @@ Describe ExportExcel -Tag "ExportExcel" {
             $excel.Workbook.Worksheets["Processes"].Dimension.rows      | Should      -Be 21    #20 data + 1 header
         }
         it "Selected  the Pivottable page                                                          " {
-            Set-ItResult -Pending -Because "Bug in EPPLus 4.5"
+            Set-ItResult -Skipped -Because "Bug in EPPLus 4.5"
             $PTws.View.TabSelected                                      | Should      -Be $true
         }
         it "Built the expected Pivot table                                                         " {

--- a/__tests__/ExtraLongCmd.tests.ps1
+++ b/__tests__/ExtraLongCmd.tests.ps1
@@ -55,7 +55,7 @@ Apple, New York, 1200,700
             $ws2.PivotTables[0].ColumGrandTotals                        | Should      -Be $true   #Epplus's mis-spelling of column not mine
         }
         it "Made the PivotTable page active                                                        " {
-            Set-ItResult -Pending -Because "Bug in EPPLus 4.5"
+            Set-ItResult -Skipped -Because "Bug in EPPLus 4.5"
             $ws2.View.TabSelected                                       | Should      -Be $true
         }
         it "Created the Pivot Chart                                                                " {

--- a/__tests__/First10Races.tests.ps1
+++ b/__tests__/First10Races.tests.ps1
@@ -93,7 +93,7 @@ Describe "Creating small named ranges with hyperlinks" {
             $sheet.ConditionalFormatting[1].StopIfTrue                  | Should      -Be $true
         }
         It "Applied ConditionalFormatting, including Reverse                                       " {
-            Set-ItResult -Pending -Because "Bug in EPPLus 4.5"
+            Set-ItResult -Skipped -Because "Bug in EPPLus 4.5"
             $sheet.ConditionalFormatting[3].LowValue.Color.R            | Should      -BegreaterThan 180
             $sheet.ConditionalFormatting[3].LowValue.Color.G            | Should      -BeLessThan 128
             $sheet.ConditionalFormatting[3].HighValue.Color.R           | Should      -BeLessThan 128

--- a/__tests__/Join-Worksheet.tests.ps1
+++ b/__tests__/Join-Worksheet.tests.ps1
@@ -54,7 +54,7 @@ Describe "Join Worksheet part 1" {
             $excel.Workbook.Worksheets["SummaryPivot"].Hidden           | Should      -Be 'Visible'
         }
         it "Activated the correct worksheet                                                        " {
-            Set-ItResult -Pending -Because "Bug in EPPLus 4.5"
+            Set-ItResult -Skipped -Because "Bug in EPPLus 4.5"
             $excel.Workbook.worksheets["SummaryPivot"].View.TabSelected | Should      -Be $true
             $excel.Workbook.worksheets["Total"].View.TabSelected        | Should      -Be $false
         }

--- a/__tests__/PasswordProtection.tests.ps1
+++ b/__tests__/PasswordProtection.tests.ps1
@@ -3,7 +3,7 @@
 Describe "Password Support" {
     if ($PSVersionTable.PSVersion.Major -GT 5) {
         It "Password Supported" {
-            Set-ItResult -Pending -Because "Can't test passwords on V6 and later"
+            Set-ItResult -Skipped -Because "Can't test passwords on V6 and later"
         }
         return
     }


### PR DESCRIPTION
Fixes #1744

## Problem

Every Azure Pipelines job currently fails on every PR — including trivial ones — before running a single test. All six jobs (e.g. on #1721, #1723, #1729, #1741, #1742) stop in the "Install and Test" step with:

```
Invoke-Pester : A parameter cannot be found that matches parameter name 'OutputFile'.
At D:\a\1\s\CI\CI.ps1:113 char:34
```

The pipeline's "Update Pester" step installs the latest Pester (currently 6.x) on every agent, but `CI/CI.ps1` still uses the Pester 4 invocation syntax: `-OutputFile` was removed in Pester 5, and the result object's `TestResult` property became `Tests`/`Failed`.

## Changes

**`CI/CI.ps1`** — when `New-PesterConfiguration` exists (Pester 5+), build a configuration object instead: `TestResult.Enabled` + `OutputPath` produce the same `TestResultsPS<version>.xml` NUnit file the `PublishTestResults` task consumes (the default output format is NUnit 2.5, matching the task's `testResultsFormat: 'NUnit'`), and `Filter.Tag`/`Filter.ExcludeTag` reproduce the `TestImportOnly` handling. Failed tests are listed from the v5 `Failed` collection. On older Pester the original code runs unchanged.

**Five tests** — with the invocation fixed, five tests still fail under Pester 5+ because `Set-ItResult -Pending` no longer exists (`Parameter set cannot be resolved...`). These are all placeholders for known EPPlus 4.5 bugs (plus one "can't test passwords on PS6+" guard); they now use `-Skipped`, which Pester 4.7+ and 5+ both support:
- `Export-Excel.Tests.ps1`, `ExtraLongCmd.tests.ps1`, `First10Races.tests.ps1`, `Join-Worksheet.tests.ps1` ("Bug in EPPLus 4.5")
- `PasswordProtection.tests.ps1` ("Can't test passwords on V6 and later")

**`Compare-WorkSheet.tests.ps1`** — the Windows PowerShell GridView test spawns a child `powershell.exe -Command $cmdline`; native argument passing mangles the embedded quotes, so the child's `Import-Module` fails whenever the repository path contains spaces and the test fails with `Expected 'FF90EE90', but got $null`. CI agents (`D:\a\1\s`) never see this, but local contributors with spaces in their clone path do. The child is now launched with `-EncodedCommand`, which sidesteps quoting entirely.

## Verification

Ran `./CI/CI.ps1 -Test` end to end (including `CI/Install.ps1`, against a sandboxed `PSModulePath`) with Pester 6.0.1:

| | Result |
|---|---|
| PowerShell 7.6 | 277 passed, 0 failed, 7 skipped |
| Windows PowerShell 5.1 | 287 total, 0 failures (NUnit XML) |
| `./CI/CI.ps1 -TestImportOnly` | tag filter selects exactly the 1 import test |

Also verified the failure branch behaves (a failing test produces the "Test failures:" listing and a non-zero exit), and that the produced `TestResultsPS*.xml` is valid NUnit 2.5 with one `test-case` per test.

This should let the pipeline actually validate the open PRs again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
